### PR TITLE
Handle missing or broken repo

### DIFF
--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -42,9 +42,14 @@ module TasteTester
         :checksum_dir => TasteTester::Config.checksum_dir,
       )
       @knife.write_user_config
-      @repo = BetweenMeals::Repo.get(TasteTester::Config.repo_type,
-                                     TasteTester::Config.repo, logger)
-      fail 'Could not read repo' unless @repo
+      @repo = BetweenMeals::Repo.get(
+        TasteTester::Config.repo_type,
+        TasteTester::Config.repo,
+        logger,
+      )
+      unless @repo.exists?
+        fail "Could not open repo from #{TasteTester::Config.repo}"
+      end
     end
 
     def checks

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -78,8 +78,14 @@ module TasteTester
         upload
       end
       server = TasteTester::Server.new
-      repo = BetweenMeals::Repo.get(TasteTester::Config.repo_type,
-                                    TasteTester::Config.repo, logger)
+      repo = BetweenMeals::Repo.get(
+        TasteTester::Config.repo_type,
+        TasteTester::Config.repo,
+        logger,
+      )
+      unless repo.exists?
+        fail "Could not open repo from #{TasteTester::Config.repo}"
+      end
       unless TasteTester::Config.skip_pre_test_hook
         TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo, hosts)
       end


### PR DESCRIPTION
This should be a critical failure. If rugged can't open the path it's either missing or malformed.
