### PR TITLE
Support using chef-zero in SSL mode.

### DIFF
--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -34,6 +34,7 @@ module TasteTester
       @knife = BetweenMeals::Knife.new(
         :logger => logger,
         :user => @server.user,
+        :ssl => TasteTester::Config.use_ssl,
         :host => @server.host,
         :port => @server.port,
         :role_dir => TasteTester::Config.roles,

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -47,7 +47,8 @@ module TasteTester
     chef_port_range [5000, 5500]
     tunnel_port 4001
     timestamp_file '/etc/chef/test_timestamp'
-    use_ssh_tunnels true
+    use_ssh_tunnels false
+    use_ssl true
 
     skip_pre_upload_hook false
     skip_post_upload_hook false

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -179,7 +179,8 @@ module TasteTester
       if TasteTester::Config.use_ssh_tunnels
         url = "http://localhost:#{@tunnel.port}"
       else
-        url = "http://#{@server.host}:#{TasteTester::State.port}"
+        scheme = TasteTester::Config.use_ssl ? 'http' : 'https'
+        url = "#{scheme}://#{@server.host}:#{TasteTester::State.port}"
       end
       ttconfig = <<-eos
 # TasteTester by #{@user}
@@ -189,12 +190,13 @@ if Process.euid != 0
   Process.exit!
 end
 
-log_level                :info
-log_location             STDOUT
-chef_server_url          '#{url}'
+log_level :info
+log_location STDOUT
+chef_server_url '#{url}'
+ssl_verify_mode :verify_none
 Ohai::Config[:plugin_path] << '/etc/chef/ohai_plugins'
 
-      eos
+eos
 
       extra = TasteTester::Hooks.test_remote_client_rb_extra_code(@name)
       if extra

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -116,6 +116,7 @@ module TasteTester
       knife = BetweenMeals::Knife.new(
         :logger => logger,
         :user => @user,
+        :ssl => TasteTester::Config.use_ssl,
         :host => @host,
         :port => port,
         :role_dir => TasteTester::Config.roles,
@@ -130,10 +131,9 @@ module TasteTester
         @state.port = TasteTester::Config.chef_port
       end
       logger.info("Starting chef-zero of port #{@state.port}")
-
-      Mixlib::ShellOut.new(
-        "#{chef_zero_path} --host #{@addr} --port #{@state.port} -d"
-      ).run_command.error!
+      cmd = "#{chef_zero_path} --host #{@addr} --port #{@state.port} -d"
+      cmd << ' --ssl' if TasteTester::Config.use_ssl
+      Mixlib::ShellOut.new(cmd).run_command.error!
     end
 
     def stop_chef_zero


### PR DESCRIPTION
This defaults to true because it's what we should be using, but
config files should turn it off if they're not ready.
