### PR TITLE
Better error handling

### DIFF
--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -108,7 +108,7 @@ module TasteTester
     def self.untest
       hosts = TasteTester::Config.servers
       unless hosts
-        logger.warn('You must provide a hostname')
+        logger.error('You must provide a hostname')
         exit(1)
       end
       server = TasteTester::Server.new

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -51,6 +51,7 @@ MSG
       # rubocop:enable LineLength
       error.lines.each { |x| logger.error x.strip }
       logger.error(e.message)
+      exit(1)
     end
 
     private


### PR DESCRIPTION
- Exit if we fail to setup a host
- If we are going to exit for something it's an error, not a warning
