### PR TITLE
Clear the ref number when restarting

### DIFF
--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -82,6 +82,7 @@ module TasteTester
       logger.warn('Restarting taste-tester server')
       if TasteTester::Server.running?
         stop_chef_zero
+        @state.ref = nil
       end
       write_config
       start_chef_zero


### PR DESCRIPTION
Currently if you do a 'taste-tester restart', then next test/upload will fail.
