### PR TITLE
Add config around chef-zero logging

### DIFF
--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -49,6 +49,7 @@ module TasteTester
     timestamp_file '/etc/chef/test_timestamp'
     use_ssh_tunnels false
     use_ssl true
+    chef_zero_logging true
 
     skip_pre_upload_hook false
     skip_post_upload_hook false

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -134,8 +134,8 @@ module TasteTester
         @state.port = TasteTester::Config.chef_port
       end
       logger.info("Starting chef-zero of port #{@state.port}")
-      cmd = "#{chef_zero_path} --host #{@addr} --port #{@state.port} -d " +
-        "--log-file #{@log_file}"
+      cmd = "#{chef_zero_path} --host #{@addr} --port #{@state.port} -d"
+      cmd << " --log-file #{@log_file}" if TasteTester::Config.chef_zero_logging
       cmd << ' --ssl' if TasteTester::Config.use_ssl
       Mixlib::ShellOut.new(cmd).run_command.error!
     end


### PR DESCRIPTION
Allow people to disable chef-zero logging - especially
if their version doesn't support it yet.
