### PR TITLE
functional Group ID matching on OSX

### DIFF
--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -49,7 +49,7 @@ module TasteTester
       else
         pid = '\\$\\$'
       end
-      cmds = "ps -p #{pid} --no-headers -o pgid > #{TasteTester::Config.timestamp_file} &&" +
+      cmds = "ps -p #{pid} -o pgid | grep -v PGID > #{TasteTester::Config.timestamp_file} &&" +
         " touch -t #{TasteTester::Config.testing_end_time}" +
         " #{TasteTester::Config.timestamp_file} && sleep #{@delta_secs}"
       # As great as it would be to have ExitOnForwardFailure=yes,


### PR DESCRIPTION
The --no-headers option does not exists in Osx world (and most likely
BSD in general). There does not seem to be a sane way to remove headers
cross platform, so defaulting to grep out PGID.
