### PR TITLE
Handle transitions between server configurations nicely

### DIFF
--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -152,7 +152,7 @@ module TasteTester
       if TasteTester::Config.force_upload
         server.restart
       else
-        server.start unless TasteTester::Server.running?
+        server.start
       end
       client = TasteTester::Client.new(server)
       client.skip_checks = true if TasteTester::Config.skip_checks

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -176,10 +176,10 @@ module TasteTester
     private
 
     def config
+      scheme = TasteTester::Config.use_ssl ? 'https' : 'http'
       if TasteTester::Config.use_ssh_tunnels
-        url = "http://localhost:#{@tunnel.port}"
+        url = "#{scheme}://localhost:#{@tunnel.port}"
       else
-        scheme = TasteTester::Config.use_ssl ? 'https' : 'http'
         url = "#{scheme}://#{@server.host}:#{TasteTester::State.port}"
       end
       ttconfig = <<-eos

--- a/lib/taste_tester/state.rb
+++ b/lib/taste_tester/state.rb
@@ -51,12 +51,40 @@ module TasteTester
       write(:port, port)
     end
 
+    def ssl
+      TasteTester::State.read(:ssl)
+    end
+
+    def ssl=(ssl)
+      write(:ssl, ssl)
+    end
+
+    def logging
+      TasteTester::State.read(:logging)
+    end
+
+    def logging=(logging)
+      write(:logging, logging)
+    end
+
+    def ssh
+      TasteTester::State.read(:ssh)
+    end
+
+    def ssh=(ssh)
+      write(:ssh, ssh)
+    end
+
     def ref
       TasteTester::State.read(:ref)
     end
 
     def ref=(ref)
       write(:ref, ref)
+    end
+
+    def update(vals)
+      merge(vals)
     end
 
     def self.port
@@ -72,13 +100,17 @@ module TasteTester
 
     private
 
-    def write(key, value)
+    def write(key, val)
+      merge({key => val})
+    end
+
+    def merge(vals)
       begin
         state = JSON.parse(File.read(TasteTester::Config.ref_file))
       rescue
         state = {}
       end
-      state[key.to_s] = value
+      state.merge!(vals)
       ff = File.open(
         TasteTester::Config.ref_file,
         'w'


### PR DESCRIPTION
Currently if you turn on SSL in a config that formerly used SSH,
you'll get a ton of errors unless users manually start. This detects the
transition and handles it for you. It also supports having both SSH and SSL at
the same time, in case you're into that sort of thing.
- Update state to store more stuff
- Make an efficient state-setter
- If the former config of chef-zero and the current config differ, restart
- Always generate the scheme dynamically
