### PR TITLE
Honor chef_zero_path; handle plugin better

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -335,8 +335,13 @@ MODES:
   TasteTester::Logging.verbosity = TasteTester::Config.verbosity
   TasteTester::Logging.use_log_formatter = TasteTester::Config.timestamp
 
-  if File.exists?(File.expand_path(TasteTester::Config.plugin_path))
-    TasteTester::Hooks.get(File.expand_path(TasteTester::Config[:plugin_path]))
+  if TasteTester::Config.plugin_path
+    path = File.expand_path(TasteTester::Config.plugin_path)
+    unless File.exists?(path)
+      logger.error("Plugin not found (#{path})")
+      exit(1)
+    end
+    TasteTester::Hooks.get(path)
   end
 
   case mode.to_sym

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -34,8 +34,8 @@ module TasteTester
     role_dir 'roles'
     databag_dir 'databags'
     config_file '/etc/taste-tester-config.rb'
-    plugin_path '/etc/taste-tester-plugin.rb'
-    chef_zero_path '/opt/chef/embedded/bin/chef-zero'
+    plugin_path nil
+    chef_zero_path nil
     verbosity Logger::WARN
     timestamp false
     user 'root'

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -167,6 +167,10 @@ module TasteTester
     end
 
     def chef_zero_path
+      if TasteTester::Config.chef_zero_path
+        return TasteTester::Config.chef_zero_path
+      end
+
       [
         '/opt/chef/bin/chef-zero',
         '/opt/chef/embedded/bin/chef-zero',


### PR DESCRIPTION
- After we worked around the move of chef-zero, we stopped honoring
  a path passed in by the user. This fixes it.
- If a user explicitly passes in a plugin path, we should error on it
  missing.
