### PR TITLE
add option to override ssh command

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -291,7 +291,7 @@ MODES:
     opts.on(
       '-e', '--ssh CMD', 'SSH command to use, defaults to "ssh".'
     ) do |cmd|
-      options[:ssh_cmd] = cmd
+      options[:ssh_command] = cmd
     end
 
     opts.on('--skip-repo-checks', 'Skip repository sanity checks') do

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -288,6 +288,12 @@ MODES:
       options[:use_ssh_tunnels] = s
     end
 
+    opts.on(
+      '-e', '--ssh CMD', 'SSH command to use, defaults to "ssh".'
+    ) do |cmd|
+      options[:ssh_cmd] = cmd
+    end
+
     opts.on('--skip-repo-checks', 'Skip repository sanity checks') do
       options[:skip_repo_checks] = true
     end

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -48,6 +48,7 @@ module TasteTester
     tunnel_port 4001
     timestamp_file '/etc/chef/test_timestamp'
     use_ssh_tunnels false
+    ssh_cmd 'ssh'
     use_ssl true
     chef_zero_logging true
 

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -48,7 +48,7 @@ module TasteTester
     tunnel_port 4001
     timestamp_file '/etc/chef/test_timestamp'
     use_ssh_tunnels false
-    ssh_cmd 'ssh'
+    ssh_command 'ssh'
     use_ssl true
     chef_zero_logging true
 

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -40,8 +40,8 @@ module TasteTester
 
     def runchef
       logger.warn("Running '#{TasteTester::Config.command}' on #{@name}")
-      cmd = "#{TasteTester::Config.ssh_cmd} "
-      cmd += "#{TasteTester::Config.user}@#{@name} "
+      cmd = "#{TasteTester::Config.ssh_command} " +
+              "#{TasteTester::Config.user}@#{@name} "
       if TasteTester::Config.user != 'root'
         cc = Base64.encode64(cmds).gsub(/\n/, '')
         cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -39,9 +39,10 @@ module TasteTester
     end
 
     def runchef
-      logger.warn("Running '#{TasteTester::Config.command}' on #{@name}")
+      logger.warn("Running '#{TasteTester::Config.chef_client_command}' " +
+                  "on #{@name}")
       cmd = "#{TasteTester::Config.ssh_command} " +
-              "#{TasteTester::Config.user}@#{@name} "
+            "#{TasteTester::Config.user}@#{@name} "
       if TasteTester::Config.user != 'root'
         cc = Base64.encode64(cmds).gsub(/\n/, '')
         cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""
@@ -59,10 +60,10 @@ module TasteTester
         io.close
         $CHILD_STATUS.to_i
       end
-      logger.warn("Finished #{TasteTester::Config.command}" +
+      logger.warn("Finished #{TasteTester::Config.chef_client_command}" +
                   " on #{@name} with status #{status}")
       if status == 0
-        msg = "#{TasteTester::Config.command} was successful" +
+        msg = "#{TasteTester::Config.chef_client_command} was successful" +
               ' - please log to the host and confirm all the intended' +
               ' changes were made'
         logger.error msg.upcase

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -40,7 +40,8 @@ module TasteTester
 
     def runchef
       logger.warn("Running '#{TasteTester::Config.command}' on #{@name}")
-      cmd = "ssh #{TasteTester::Config.user}@#{@name} "
+      cmd = "#{TasteTester::Config.ssh_cmd} "
+      cmd += "#{TasteTester::Config.user}@#{@name} "
       if TasteTester::Config.user != 'root'
         cc = Base64.encode64(cmds).gsub(/\n/, '')
         cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -64,8 +64,8 @@ MSG
       end
       cmds = @cmds.join(' && ')
       cmd = "#{TasteTester::Config.ssh_command} " +
-              "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
-              "#{TasteTester::Config.user}@#{@host} "
+            "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
+            "#{TasteTester::Config.user}@#{@host} "
       if TasteTester::Config.user != 'root'
         cc = Base64.encode64(cmds).gsub(/\n/, '')
         cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -47,7 +47,7 @@ module TasteTester
 SSH returned error while connecting to #{TasteTester::Config.user}@#{@host}
 The host might be broken or your SSH access is not working properly
 Try doing
-  #{TasteTester::Config.ssh_cmd} -v #{TasteTester::Config.user}@#{@host}
+  #{TasteTester::Config.ssh_command} -v #{TasteTester::Config.user}@#{@host}
 and come back once that works
 MSG
       # rubocop:enable LineLength
@@ -63,9 +63,9 @@ MSG
         logger.info("Will run: '#{cmd}' on #{@host}")
       end
       cmds = @cmds.join(' && ')
-      cmd = "#{TasteTester::Config.ssh_cmd} "
-      cmd += "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} "
-      cmd += "#{TasteTester::Config.user}@#{@host} "
+      cmd = "#{TasteTester::Config.ssh_command} " +
+              "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
+              "#{TasteTester::Config.user}@#{@host} "
       if TasteTester::Config.user != 'root'
         cc = Base64.encode64(cmds).gsub(/\n/, '')
         cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -46,7 +46,9 @@ module TasteTester
       error = <<-MSG
 SSH returned error while connecting to #{TasteTester::Config.user}@#{@host}
 The host might be broken or your SSH access is not working properly
-Try doing 'ssh -v #{TasteTester::Config.user}@#{@host}' and come back once that works
+Try doing
+  #{TasteTester::Config.ssh_cmd} -v #{TasteTester::Config.user}@#{@host}
+and come back once that works
 MSG
       # rubocop:enable LineLength
       error.lines.each { |x| logger.error x.strip }
@@ -61,7 +63,8 @@ MSG
         logger.info("Will run: '#{cmd}' on #{@host}")
       end
       cmds = @cmds.join(' && ')
-      cmd = "ssh -T -o BatchMode=yes -o ConnectTimeout=#{@timeout} "
+      cmd = "#{TasteTester::Config.ssh_cmd} "
+      cmd += "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} "
       cmd += "#{TasteTester::Config.user}@#{@host} "
       if TasteTester::Config.user != 'root'
         cc = Base64.encode64(cmds).gsub(/\n/, '')

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -58,7 +58,8 @@ module TasteTester
       # In most cases the first request from chef was "breaking" the tunnel,
       # in a way that port was still open, but subsequent requests were hanging.
       # This is reproducible and should be looked into.
-      cmd = "ssh -T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
+      cmd = "#{TasteTester::Config.ssh_cmd} " +
+        "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
         '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' +
         '-o ServerAliveInterval=10 -o ServerAliveCountMax=6 ' +
         "-f -R #{@port}:localhost:#{@server.port} "

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -58,7 +58,7 @@ module TasteTester
       # In most cases the first request from chef was "breaking" the tunnel,
       # in a way that port was still open, but subsequent requests were hanging.
       # This is reproducible and should be looked into.
-      cmd = "#{TasteTester::Config.ssh_cmd} " +
+      cmd = "#{TasteTester::Config.ssh_command} " +
         "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
         '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' +
         '-o ServerAliveInterval=10 -o ServerAliveCountMax=6 ' +


### PR DESCRIPTION
Add a new option to taste-tester to override the command used for ssh, akin to the 'rsync -e' option.