### PR TITLE
adding --no-ipv6 parameter to toggle chef-zero bind host

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -302,6 +302,13 @@ MODES:
       options[:skip_repo_checks] = true
     end
 
+    opts.on(
+      '--ipv6 BOOLEAN', TrueClass,
+        'Enable/Disable IPv6 chef-zero bind host and' +
+        ' bind to IPv4 host instead.') do |i|
+      options[:ipv6] = i
+    end
+
     opts.on('-y', '--yes', 'Do not prompt before testing.') do
       options[:yes] = true
     end

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -52,6 +52,7 @@ module TasteTester
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'
+    ipv6 false
 
     skip_pre_upload_hook false
     skip_post_upload_hook false

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -62,6 +62,7 @@ module TasteTester
         @host = 'localhost'
       else
         @addr = '::'
+        @addr = '0.0.0.0' unless TasteTester::Config.ipv6
         begin
           @host = Socket.gethostname
         rescue


### PR DESCRIPTION
By default the chef-zero server instance started by taste-tester binds to the ::1 host. When running taste-tester with ssl enabled, IPv4 only servers cannot communicate with the ::1 chef-zero instance.

To remedy this we initially thought we could pass multiple --host parameters to chef-zero, but that doesn't work upon testing. What happens is the last --host parameter is used because only one --host parameter is allowed by chef-zero.

Also, in the chef-zero codebase this section in the below link shows that chef-zero only publishes one URI for its server instance address" https://github.com/chef/chef-zero/blob/master/lib/chef_zero/server.rb#L167

Test Plan:

- Add a new parameter called --no-ipv6 that toggles a True/False Class to control the host bind port of the taste-tester chef-zero instance.
- Verify the host bind address by starting the chef-zero server instance with the --no-ipv6 parameter:
```
# taste-tester start --chef-port-range 5999,5999 -y -v -l --no-ipv6
Loading plugin at /etc/taste-tester-plugin.rb
Starting taste-tester server
INFO: Starting chef-zero of port 5999

# ps  aux |grep 5999 | grep -v grep
5    30783  0.1  0.4 274552 18264 ?        Sl   12:45   0:00 /usr/local/ittools/ruby-2.2.4/bin/ruby /usr/local/ittools/ruby/bin/chef-zero --host 0.0.0.0 --port 5999 -d --ssl

# netstat -tlnp |grep 5999
tcp        0      0 0.0.0.0:5999                0.0.0.0:*                   LISTEN      30783/ruby 
```
- Verify the host bind address by starting the chef-zero server instance without the --no-ipv6 parameter:
```
# taste-tester start --chef-port-range 5999,5999 -y -v -l
Loading plugin at /etc/taste-tester-plugin.rb
Starting taste-tester server
INFO: Starting chef-zero of port 5999

# ps  aux |grep 5999 | grep -v grep
5    31909  0.5  0.4 274544 18260 ?        Sl   12:46   0:00 /usr/local/ittools/ruby-2.2.4/bin/ruby /usr/local/ittools/ruby/bin/chef-zero --host :: --port 5999 -d --ssl

# netstat -tlnp |grep 5999
tcp        0      0 :::5999                     :::*                        LISTEN      31909/ruby
```

By default the taste-tester still uses the IPv6 compatible ::1 host bind address for its chef-zero server instance. As shown above you have to explicitly disable ipv6.