### PR TITLE
updated Ohai plugin path config

### DIFF
--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -205,7 +205,7 @@ log_level :info
 log_location STDOUT
 chef_server_url '#{url}'
 ssl_verify_mode :verify_none
-Ohai::Config[:plugin_path] << '#{TasteTester::Config.chef_config_path}/ohai_plugins'
+ohai.plugin_path << '#{TasteTester::Config.chef_config_path}/ohai_plugins'
 
 eos
       # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
Fix this warning:

`WARN: Ohai::Config[:plugin_path] is set. Ohai::Config[:plugin_path] is deprecated and will be removed in future releases of ohai. Use ohai.plugin_path in your configuration file to configure :plugin_path for ohai.`