### PR TITLE
Updated rubocop config, re-linted everything

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,12 +80,35 @@ FileName:
 PerceivedComplexity:
   Enabled: false
 
-TrailingComma:
-  Enabled: false
+TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
 
 UnneededDisable:
   Enabled: false
 
+MultilineOperationIndentation:
+  Enabled: false
+
+Performance/RedundantMatch:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Performance/TimesMap:
+  Enabled: false
+
+Performance/RedundantMerge:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/IndentArray:
+  EnforcedStyle: consistent
 #
 # Modified rules
 #
@@ -97,3 +120,6 @@ DotPosition:
 
 HashSyntax:
   EnforcedStyle: hash_rockets
+
+Style/Documentation:
+  Enabled: false

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -45,7 +45,7 @@ module TasteTester
   # that if people override chef_client_command the help message is correct.
   if File.exists?(File.expand_path(TasteTester::Config.config_file))
     TasteTester::Config.from_file(
-      File.expand_path(TasteTester::Config.config_file)
+      File.expand_path(TasteTester::Config.config_file),
     )
   end
 
@@ -255,7 +255,7 @@ MODES:
 
     opts.on(
       '--repo-type TYPE',
-      'Override repo type, default is auto.'
+      'Override repo type, default is auto.',
     ) do |type|
       options[:repo_type] = type
     end

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -115,7 +115,7 @@ MODES:
     should be no need to do this manually.
   EOF
 
-  mode = ARGV.shift unless ARGV.size > 0 && ARGV[0].start_with?('-')
+  mode = ARGV.shift unless !ARGV.empty? && ARGV[0].start_with?('-')
 
   unless mode
     mode = 'help'

--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -51,7 +51,7 @@ module TasteTester
         logger,
       )
       unless @repo.exists?
-        fail "Could not open repo from #{TasteTester::Config.repo}"
+        raise "Could not open repo from #{TasteTester::Config.repo}"
       end
     end
 

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -83,7 +83,7 @@ module TasteTester
         logger,
       )
       unless repo.exists?
-        fail "Could not open repo from #{TasteTester::Config.repo}"
+        raise "Could not open repo from #{TasteTester::Config.repo}"
       end
       unless TasteTester::Config.skip_pre_test_hook
         TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo, hosts)

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -44,13 +44,13 @@ module TasteTester
       cmd = "#{TasteTester::Config.ssh_command} " +
             "#{TasteTester::Config.user}@#{@name} "
       if TasteTester::Config.user != 'root'
-        cc = Base64.encode64(cmds).gsub(/\n/, '')
+        cc = Base64.encode64(cmds).delete("\n")
         cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""
       else
         cmd += "\"#{cmds}\""
       end
       status = IO.popen(
-        cmd
+        cmd,
       ) do |io|
         # rubocop:disable AssignmentInCondition
         while line = io.gets
@@ -81,7 +81,7 @@ module TasteTester
         @tunnel.run
       end
 
-      @serialized_config = Base64.encode64(config).gsub(/\n/, '')
+      @serialized_config = Base64.encode64(config).delete("\n")
 
       # Then setup the testing
       ssh = TasteTester::SSH.new(@name)
@@ -100,7 +100,7 @@ module TasteTester
       # Then run any other stuff they wanted
       cmds = TasteTester::Hooks.test_remote_cmds(
         TasteTester::Config.dryrun,
-        @name
+        @name,
       )
 
       if cmds && cmds.any?

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -150,7 +150,7 @@ module TasteTester
                       :ssl => TasteTester::Config.use_ssl,
                       :ssh => TasteTester::Config.use_ssh_tunnels,
                       :logging => TasteTester::Config.chef_zero_logging,
-                    })
+                    },)
       logger.info("Starting chef-zero of port #{@state.port}")
       cmd = "#{chef_zero_path} --host #{@addr} --port #{@state.port} -d"
       cmd << " --log-file #{@log_file}" if TasteTester::Config.chef_zero_logging

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -35,7 +35,7 @@ module TasteTester
       @cmds << string
     end
 
-    alias_method :<<, :add
+    alias << add
 
     def run
       @status, @output = exec(cmd, logger)
@@ -69,7 +69,7 @@ MSG
             "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
             "#{TasteTester::Config.user}@#{@host} "
       if TasteTester::Config.user != 'root'
-        cc = Base64.encode64(cmds).gsub(/\n/, '')
+        cc = Base64.encode64(cmds).delete("\n")
         cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""
       else
         cmd += "\'#{cmds}\'"

--- a/lib/taste_tester/state.rb
+++ b/lib/taste_tester/state.rb
@@ -30,7 +30,7 @@ module TasteTester
 
     def initialize
       ref_dir = File.dirname(File.expand_path(
-                               TasteTester::Config.ref_file
+                               TasteTester::Config.ref_file,
       ))
       unless File.directory?(ref_dir)
         begin
@@ -98,6 +98,15 @@ module TasteTester
       end
     end
 
+    def self.read(key)
+      JSON.parse(File.read(TasteTester::Config.ref_file))[key.to_s]
+    rescue => e
+      logger.debug(e)
+      nil
+    end
+
+    private_class_method :read
+
     private
 
     def write(key, val)
@@ -113,7 +122,7 @@ module TasteTester
       state.merge!(vals)
       ff = File.open(
         TasteTester::Config.ref_file,
-        'w'
+        'w',
       )
       ff.write(state.to_json)
       ff.close
@@ -121,13 +130,6 @@ module TasteTester
       logger.error('Unable to write the reffile')
       logger.debug(e)
       exit 0
-    end
-
-    def self.read(key)
-      JSON.parse(File.read(TasteTester::Config.ref_file))[key.to_s]
-    rescue => e
-      logger.debug(e)
-      nil
     end
   end
 end

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -65,7 +65,7 @@ module TasteTester
             '-o ServerAliveInterval=10 -o ServerAliveCountMax=6 ' +
             "-f -R #{@port}:localhost:#{@server.port} "
       if TasteTester::Config.user != 'root'
-        cc = Base64.encode64(cmds).gsub(/\n/, '')
+        cc = Base64.encode64(cmds).delete("\n")
         cmd += "#{TasteTester::Config.user}@#{@host} \"echo '#{cc}' | base64" +
                ' --decode | sudo bash -x"'
       else


### PR DESCRIPTION
The rubocop config was out of date, as pointed out in  https://github.com/facebook/taste-tester/pull/48. I've updated it to configure the
most recent cops. I ran the new config across all existing files and
corrected things to get rid of the warnings and errors.