### PR TITLE
Add argument to specify the hostname of your local machine

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -207,6 +207,12 @@ MODES:
     end
 
     opts.on(
+      '-m', '--my-hostname HOSTNAME', String, 'Hostname for local chef server'
+    ) do |hostname|
+      options[:my_hostname] = hostname
+    end
+
+    opts.on(
       '-l', '--linkonly', 'Only setup the remote server, skip uploading.'
     ) do
       options[:linkonly] = true

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -53,6 +53,7 @@ module TasteTester
     chef_zero_logging true
     chef_config_path '/etc/chef'
     chef_config 'client.rb'
+    my_hostname nil
 
     skip_pre_upload_hook false
     skip_post_upload_hook false

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -63,7 +63,7 @@ module TasteTester
       else
         @addr = '::'
         begin
-          @host = Socket.gethostname
+          @host = TasteTester::Config.my_hostname || Socket.gethostname
         rescue
           logger.error('Unable to find fqdn')
           exit 1


### PR DESCRIPTION
This allows you to override @host in server.rb, which by default is Socket.gethostname. Socket.gethostname does not work reliably when DNS is not accurate, so this allows you to manually specify a hostname (IP addresses work as well).

I tested this using '[::1]' as well as my hostname and both situations worked as expected. Also tested setting my_hostname in taste_tester_config.rb and it worked as expected.