### PR TITLE
Add locallink option - setup chef client for taste-tester on local sy…

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -219,6 +219,12 @@ MODES:
     end
 
     opts.on(
+      '-L', '--locallink', 'Configure the local chef client without ssh.'
+    ) do
+      options[:locallink] = true
+    end
+
+    opts.on(
       '-t', '--testing-timestamp TIME',
         'Until when should the host remain in testing.' +
         ' Anything parsable is ok, such as "5/18 4:35" or "16/9/13".'

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -87,7 +87,7 @@ module TasteTester
           raise "Could not open repo from #{TasteTester::Config.repo}"
         end
       end
-      unless TasteTester::Config.skip_pre_test_hook || 
+      unless TasteTester::Config.skip_pre_test_hook ||
           TasteTester::Config.linkonly
         TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo, hosts)
       end
@@ -102,7 +102,7 @@ module TasteTester
           tested_hosts << hostname
         end
       end
-      unless TasteTester::Config.skip_post_test_hook || 
+      unless TasteTester::Config.skip_post_test_hook ||
           TasteTester::Config.linkonly
         TasteTester::Hooks.post_test(TasteTester::Config.dryrun, repo,
                                      tested_hosts)

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -77,15 +77,17 @@ module TasteTester
         upload
       end
       server = TasteTester::Server.new
-      repo = BetweenMeals::Repo.get(
-        TasteTester::Config.repo_type,
-        TasteTester::Config.repo,
-        logger,
-      )
-      unless repo.exists?
-        raise "Could not open repo from #{TasteTester::Config.repo}"
+      unless TasteTester::Config.linkonly
+        repo = BetweenMeals::Repo.get(
+          TasteTester::Config.repo_type,
+          TasteTester::Config.repo,
+          logger,
+        )
+        unless repo.exists?
+          raise "Could not open repo from #{TasteTester::Config.repo}"
+        end
       end
-      unless TasteTester::Config.skip_pre_test_hook
+      unless TasteTester::Config.skip_pre_test_hook || TasteTester::Config.linkonly
         TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo, hosts)
       end
       tested_hosts = []
@@ -99,7 +101,7 @@ module TasteTester
           tested_hosts << hostname
         end
       end
-      unless TasteTester::Config.skip_post_test_hook
+      unless TasteTester::Config.skip_post_test_hook || TasteTester::Config.linkonly
         TasteTester::Hooks.post_test(TasteTester::Config.dryrun, repo,
                                      tested_hosts)
       end

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -87,7 +87,8 @@ module TasteTester
           raise "Could not open repo from #{TasteTester::Config.repo}"
         end
       end
-      unless TasteTester::Config.skip_pre_test_hook || TasteTester::Config.linkonly
+      unless TasteTester::Config.skip_pre_test_hook || 
+          TasteTester::Config.linkonly
         TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo, hosts)
       end
       tested_hosts = []
@@ -101,7 +102,8 @@ module TasteTester
           tested_hosts << hostname
         end
       end
-      unless TasteTester::Config.skip_post_test_hook || TasteTester::Config.linkonly
+      unless TasteTester::Config.skip_post_test_hook || 
+          TasteTester::Config.linkonly
         TasteTester::Hooks.post_test(TasteTester::Config.dryrun, repo,
                                      tested_hosts)
       end

--- a/lib/taste_tester/exceptions.rb
+++ b/lib/taste_tester/exceptions.rb
@@ -18,5 +18,7 @@ module TasteTester
   module Exceptions
     class SshError < StandardError
     end
+    class LocalLinkError < StandardError
+    end
   end
 end

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -20,6 +20,7 @@ require 'open3'
 require 'colorize'
 
 require 'taste_tester/ssh'
+require 'taste_tester/locallink'
 require 'taste_tester/tunnel'
 
 module TasteTester
@@ -70,6 +71,14 @@ module TasteTester
       end
     end
 
+    def get_transport
+      if TasteTester::Config.locallink
+        transport = TasteTester::LocalLink.new()
+      else
+        transport = TasteTester::SSH.new(@name)
+      end
+    end
+
     def test
       logger.warn("Taste-testing on #{@name}")
 
@@ -84,19 +93,20 @@ module TasteTester
       @serialized_config = Base64.encode64(config).delete("\n")
 
       # Then setup the testing
-      ssh = TasteTester::SSH.new(@name)
-      ssh << 'logger -t taste-tester Moving server into taste-tester' +
+      transport = get_transport
+
+      transport << 'logger -t taste-tester Moving server into taste-tester' +
         " for #{@user}"
-      ssh << "touch -t #{TasteTester::Config.testing_end_time}" +
+      transport << "touch -t #{TasteTester::Config.testing_end_time}" +
         " #{TasteTester::Config.timestamp_file}"
-      ssh << "echo -n '#{@serialized_config}' | base64 --decode" +
+      transport << "echo -n '#{@serialized_config}' | base64 --decode" +
         " > #{TasteTester::Config.chef_config_path}/client-taste-tester.rb"
-      ssh << "rm -vf #{TasteTester::Config.chef_config_path}/" +
+      transport << "rm -vf #{TasteTester::Config.chef_config_path}/" +
         TasteTester::Config.chef_config
-      ssh << "( ln -vs #{TasteTester::Config.chef_config_path}" +
+      transport << "( ln -vs #{TasteTester::Config.chef_config_path}" +
         "/client-taste-tester.rb #{TasteTester::Config.chef_config_path}/" +
         "#{TasteTester::Config.chef_config}; true )"
-      ssh.run!
+      transport.run!
 
       # Then run any other stuff they wanted
       cmds = TasteTester::Hooks.test_remote_cmds(
@@ -105,15 +115,15 @@ module TasteTester
       )
 
       if cmds && cmds.any?
-        ssh = TasteTester::SSH.new(@name)
-        cmds.each { |c| ssh << c }
-        ssh.run!
+        transport = get_transport
+        cmds.each { |c| transport << c }
+        transport.run!
       end
     end
 
     def untest
       logger.warn("Removing #{@name} from taste-tester")
-      ssh = TasteTester::SSH.new(@name)
+      transport = get_transport
       if TasteTester::Config.use_ssh_tunnels
         TasteTester::Tunnel.kill(@name)
       end
@@ -131,17 +141,17 @@ module TasteTester
         "rm -vf #{TasteTester::Config.timestamp_file}",
         'logger -t taste-tester Returning server to production',
       ].each do |cmd|
-        ssh << cmd
+        transport << cmd
       end
-      ssh.run!
+      transport.run!
     end
 
     def who_is_testing
-      ssh = TasteTester::SSH.new(@name)
-      ssh << 'grep "^# TasteTester by"' +
+      transport = get_transport
+      transport << 'grep "^# TasteTester by"' +
         " #{TasteTester::Config.chef_config_path}/" +
         TasteTester::Config.chef_config
-      output = ssh.run
+      output = transport.run
       if output.first.zero?
         user = output.last.match(/# TasteTester by (.*)$/)
         if user
@@ -150,10 +160,10 @@ module TasteTester
       end
 
       # Legacy FB stuff, remove after migration. Safe for everyone else.
-      ssh = TasteTester::SSH.new(@name)
-      ssh << "file #{TasteTester::Config.chef_config_path}/" +
+      transport = get_transport
+      transport << "file #{TasteTester::Config.chef_config_path}/" +
         TasteTester::Config.chef_config
-      output = ssh.run
+      output = transport.run
       if output.first.zero?
         user = output.last.match(/client-(.*)-(taste-tester|test).rb/)
         if user
@@ -165,9 +175,10 @@ module TasteTester
     end
 
     def in_test?
-      ssh = TasteTester::SSH.new(@name)
-      ssh << "test -f #{TasteTester::Config.timestamp_file}"
-      if ssh.run.first.zero? && who_is_testing && who_is_testing != ENV['USER']
+      transport = get_transport
+      transport << "test -f #{TasteTester::Config.timestamp_file}"
+      if transport.run.first.zero? && who_is_testing &&
+          who_is_testing != ENV['USER']
         true
       else
         false
@@ -182,10 +193,10 @@ module TasteTester
         @tunnel = TasteTester::Tunnel.new(@name, @server)
         @tunnel.run
       else
-        ssh = TasteTester::SSH.new(@name)
-        ssh << "touch -t #{TasteTester::Config.testing_end_time}" +
+        transport = get_transport
+        transport << "touch -t #{TasteTester::Config.testing_end_time}" +
           " #{TasteTester::Config.timestamp_file}"
-        ssh.run!
+        transport.run!
       end
     end
 
@@ -196,7 +207,8 @@ module TasteTester
       if TasteTester::Config.use_ssh_tunnels
         url = "#{scheme}://localhost:#{@tunnel.port}"
       else
-        url = "#{scheme}://#{@server.host}:#{TasteTester::State.port}"
+        url = "#{scheme}://#{@server.host}"
+        url << ":#{TasteTester::State.port}" if TasteTester::State.port
       end
       # rubocop:disable Metrics/LineLength
       ttconfig = <<-eos

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -73,10 +73,11 @@ module TasteTester
 
     def get_transport
       if TasteTester::Config.locallink
-        transport = TasteTester::LocalLink.new()
+        transport = TasteTester::LocalLink.new
       else
         transport = TasteTester::SSH.new(@name)
       end
+      transport
     end
 
     def test

--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -1,0 +1,65 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+# Copyright 2013-present Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'taste_tester/exceptions'
+
+module TasteTester
+  # Wrapper for running commands on local system
+  class LocalLink
+    include TasteTester::Logging
+    include BetweenMeals::Util
+
+    attr_reader :output
+
+    def initialize
+      @host = 'localhost'
+      @cmds = []
+    end
+
+    def add(string)
+      @cmds << string
+    end
+
+    alias << add
+
+    def run
+      @status, @output = exec(cmd, logger)
+    end
+
+    def run!
+      @status, @output = exec!(cmd, logger)
+    rescue => e
+      logger.error(e.message)
+      raise TasteTester::Exceptions::LocalLinkError
+    end
+
+    private
+
+    def cmd
+      @cmds.each do |cmd|
+        logger.info("Will run: '#{cmd}' on #{@host}")
+      end
+      cmds = @cmds.join(' && ')
+      if TasteTester::Config.user != 'root'
+        cc = Base64.encode64(cmds).delete("\n")
+        cmd = "echo '#{cc}' | base64 --decode | sudo bash -x"
+      else
+        cmd = "#{cmds}"
+      end
+      cmd
+    end
+  end
+end

--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -57,7 +57,7 @@ module TasteTester
         cc = Base64.encode64(cmds).delete("\n")
         cmd = "echo '#{cc}' | base64 --decode | sudo bash -x"
       else
-        cmd = "#{cmds}"
+        cmd = cmds.to_s
       end
       cmd
     end


### PR DESCRIPTION
…stem

- Create a "locallink" option, which will operate upon the local chef client configuration without using ssh
- Set chef server port only when it has a value
- Do not touch repo when linkonly is set in test subcommand