### PR TITLE
Windows Native `taste-tester upload`

### DIFF
--- a/lib/taste_tester/windows.rb
+++ b/lib/taste_tester/windows.rb
@@ -17,17 +17,13 @@
 module TasteTester
   module Windows
     def start_win_chef_zero_server
-      # `START` needs quotes around one of the arguments to function correctly.
-      # rubocop:disable Lint/PercentStringArray
-      cmd = %W{
-        START "taste-tester"
-        /MIN
-        #{TasteTester::Config.chef_zero_path}
-        --port #{@state.port}
-        --host #{@addr}
-      }.join(' ')
-      # rubocop:enable Lint/PercentStringArray
+      cmd = "#{TasteTester::Config.chef_zero_path} --port #{@state.port}"
 
+      if TasteTester::Config.my_hostname
+        cmd << " --host #{TasteTester::Config.my_hostname}"
+      else
+        cmd << " --host #{@addr}"
+      end
       if TasteTester::Config.chef_zero_logging
         cmd << " --log-file #{@log_file} --log-level debug"
       end
@@ -41,17 +37,12 @@ module TasteTester
       sleep(2)
     end
 
-    # `START` will also create a parent process for `cmd.exe` when `ruby.exe` is
-    # created, so we also need to make sure that we find those and kill them
-    # after the ruby process is terminated. Otherwise many orphaned `cmd.exe`
-    # windows could be left open in the aftermath.
     def find_cz_pids
       require 'wmi-lite'
       wmi = WmiLite::Wmi.new
       cz_process_query = %{
         SELECT
-          ProcessID,
-          ParentProcessID
+          ProcessID
         FROM
           Win32_Process
         WHERE
@@ -60,16 +51,15 @@ module TasteTester
           Name = "ruby.exe"
       }
       wmi.query(cz_process_query).map do |process|
-        [process['processid'], process['parentprocessid']]
+        process['processid']
       end
     end
 
     # It is possible to have multiple chef-zero processes running which may
     # mess up taste-tester's state. So... nuke 'em all.
     def nuke_all_cz_pids
-      find_cz_pids.each do |pid, parentpid|
+      find_cz_pids.each do |pid|
         ::Mixlib::ShellOut.new("taskkill /F /PID #{pid}").run_command
-        ::Mixlib::ShellOut.new("taskkill /F /PID #{parentpid}").run_command
       end
     end
   end

--- a/lib/taste_tester/windows.rb
+++ b/lib/taste_tester/windows.rb
@@ -1,0 +1,75 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+# Copyright 2013-present Facebook
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module TasteTester
+  module Windows
+    def start_win_chef_zero_server
+      # `START` needs quotes around one of the arguments to function correctly.
+      # rubocop:disable Lint/PercentStringArray
+      cmd = %W{
+        START "taste-tester"
+        /MIN
+        #{TasteTester::Config.chef_zero_path}
+        --port #{@state.port}
+      }.join(' ')
+      # rubocop:enable Lint/PercentStringArray
+
+      if TasteTester::Config.chef_zero_logging
+        cmd << " --log-file #{@log_file} --log-level debug"
+      end
+      if TasteTester::Config.use_ssl
+        cmd << ' --ssl'
+      end
+
+      # Mixlib::Shellout will always wait for a process to finish before
+      # returning, so we use `spawn` instead.
+      spawn(cmd)
+      sleep(2)
+    end
+
+    # `START` will also create a parent process for `cmd.exe` when `ruby.exe` is
+    # created, so we also need to make sure that we find those and kill them
+    # after the ruby process is terminated. Otherwise many orphaned `cmd.exe`
+    # windows could be left open in the aftermath.
+    def find_cz_pids
+      require 'wmi-lite'
+      wmi = WmiLite::Wmi.new
+      cz_process_query = %{
+        SELECT
+          ProcessID,
+          ParentProcessID
+        FROM
+          Win32_Process
+        WHERE
+          CommandLine LIKE "%chef-zero%"
+          AND
+          Name = "ruby.exe"
+      }
+      wmi.query(cz_process_query).map do |process|
+        [process['processid'], process['parentprocessid']]
+      end
+    end
+
+    # It is possible to have multiple chef-zero processes running which may
+    # mess up taste-tester's state. So... nuke 'em all.
+    def nuke_all_cz_pids
+      find_cz_pids.each do |pid, parentpid|
+        ::Mixlib::ShellOut.new("taskkill /F /PID #{pid}").run_command
+        ::Mixlib::ShellOut.new("taskkill /F /PID #{parentpid}").run_command
+      end
+    end
+  end
+end

--- a/lib/taste_tester/windows.rb
+++ b/lib/taste_tester/windows.rb
@@ -24,6 +24,7 @@ module TasteTester
         /MIN
         #{TasteTester::Config.chef_zero_path}
         --port #{@state.port}
+        --host #{@addr}
       }.join(' ')
       # rubocop:enable Lint/PercentStringArray
 


### PR DESCRIPTION
These changes will let you `upload` a chef development repo to `taste-tester` natively on Windows.

* Windows cannot run `chef-zero` with the `--daemon` flag, so instead we create a scheduled task that will spawn a `chef-zero` process. The side-effect of this is that a window will remain open for the duration of the testing.
* Added a Windows module to contain windows specific code
* Shifted order of taste-tester issuing the `@state.wipe` when in `stop` mode.
* Added `pid` method to `State` class so it can infer the chef-zero process id
* Added `windows?` method to `Server` class so it only executes windows specific code.