### PR TITLE
add default windows paths

### DIFF
--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -56,6 +56,13 @@ module TasteTester
     chef_config 'client.rb'
     my_hostname nil
 
+    if Gem.win_platform?
+      timestamp_file 'C:/chef/test_timestamp'
+      config_file 'C:/chef/taste-tester-config.rb'
+      chef_config_path 'C:/chef'
+      chef_zero_path 'C:\opscode\chef\embedded\bin\chef-zero.bat'
+    end
+
     skip_pre_upload_hook false
     skip_post_upload_hook false
     skip_pre_test_hook false


### PR DESCRIPTION
The default paths to some of the settings isn't Windows friendly unless you explicitly provide it in a config file. Let's make this slightly more delightful! Not sure how we want to handle per-OS checks but this will at least get that discussion going 😉 

This works on my machine (sans `upload` since our repo structures are different) for `start` and `stop` commands without needing to tell `taste-tester` where everything is!