### PR TITLE
Remove old dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.1.9
-  - 2.2.0
+  - 2.2.2
+  - 2.3.4
+  - 2.4.0
 
 gemfile:
   - Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ gemspec
 group :test, :development do
   gem 'between_meals', :git => 'https://github.com/facebook/between-meals'
 end
-
-gem 'mixlib-shellout', '2.2.7'


### PR DESCRIPTION
We no longer need to pin to mixlib-shellout and should begin testing on 2.4