### PR TITLE
Fix rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.1
   Exclude:
+    # minor edit to trigger run
     # template files named `rb` instead of `erb` are a sin against ruby-nature.
     - '**/templates/**/*.rb'#
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -146,9 +146,6 @@ HashSyntax:
 Style/Documentation:
   Enabled: false
 
-TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: comma
-
 TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.1
   Exclude:
-    # minor edit to trigger run
     # template files named `rb` instead of `erb` are a sin against ruby-nature.
     - '**/templates/**/*.rb'#
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-AllCops:  
-  TargetRubyVersion: 2.1  
+AllCops:
+  TargetRubyVersion: 2.1
   Exclude:
     # template files named `rb` instead of `erb` are a sin against ruby-nature.
     - '**/templates/**/*.rb'#
@@ -129,7 +129,7 @@ Naming/HeredocDelimiterNaming:
 
 # This double-reports what happens in EmptyLines
 Layout/EmptyLineBetweenDefs:
-  Enabled: false      
+  Enabled: false
 
 #
 # Modified rules
@@ -147,6 +147,12 @@ Style/Documentation:
   Enabled: false
 
 TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 TrailingCommaInArguments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,9 +173,6 @@ Naming/VariableNumber:
 Style/RegexpLiteral:
   EnforcedStyle: mixed
 
-Metrics/BlockLength:
-  Enabled: false
-
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: {}

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -223,7 +223,6 @@ module TasteTester
         url = "#{scheme}://#{@server.host}"
         url << ":#{TasteTester::State.port}" if TasteTester::State.port
       end
-      # rubocop:disable Metrics/LineLength
       ttconfig = <<-EOS
 # TasteTester by #{@user}
 # Prevent people from screwing up their permissions
@@ -239,7 +238,6 @@ ssl_verify_mode :verify_none
 ohai.plugin_path << '#{TasteTester::Config.chef_config_path}/ohai_plugins'
 
 EOS
-      # rubocop:enable Metrics/LineLength
 
       extra = TasteTester::Hooks.test_remote_client_rb_extra_code(@name)
       if extra

--- a/lib/taste_tester/logging.rb
+++ b/lib/taste_tester/logging.rb
@@ -35,8 +35,8 @@ module TasteTester
       @logger ||= Logger.new(STDOUT)
     end
 
-    def self.formatterproc=(p)
-      @@formatter_proc = p
+    def self.formatterproc=(process)
+      @@formatter_proc = process
     end
 
     def self.use_log_formatter=(use_log_formatter)

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -44,7 +44,6 @@ module TasteTester
     def run!
       @status, @output = exec!(cmd, logger)
     rescue StandardError => e
-      # rubocop:disable LineLength
       error = <<-MSG
 SSH returned error while connecting to #{TasteTester::Config.user}@#{@host}
 The host might be broken or your SSH access is not working properly
@@ -52,7 +51,6 @@ Try doing
   #{TasteTester::Config.ssh_command} -v #{TasteTester::Config.user}@#{@host}
 and come back once that works
 MSG
-      # rubocop:enable LineLength
       error.lines.each { |x| logger.error x.strip }
       logger.error(e.message)
       raise TasteTester::Exceptions::SshError

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.executables = 'taste-tester'
   s.license = 'Apache'
   s.add_dependency 'between_meals', '>= 0.0.6'
+  s.add_dependency 'json', '>= 2.0.0'
   %w{
     mixlib-config
     colorize

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.executables = 'taste-tester'
   s.license = 'Apache'
   s.add_dependency 'between_meals', '>= 0.0.6'
+  # without an explicit dependency, json is resolved to 1.7.7 on Ruby 2.4
+  # which doesn't compile.
   s.add_dependency 'json', '>= 2.0.0'
   %w{
     mixlib-config


### PR DESCRIPTION
Highlighted when proposing https://github.com/facebook/taste-tester/pull/88

Should be backward compatible:

```
[user@server ~/local/taste-tester] /opt/chef/embedded/bin/rubocop -v
0.52.0
[user@server ~/local/taste-tester]
/opt/chef/embedded/bin/rubocop
Warning: unrecognized cop TrailingCommaInArrayLiteral found in .rubocop.yml
Warning: unrecognized cop TrailingCommaInHashLiteral found in .rubocop.yml
Inspecting 20 files
....................

20 files inspected, no offenses detected
```

Also removed trailing whitespace