### PR TITLE
Remove Ruby 2.4 as a continuous build target

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,14 +17,9 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/ruby:2.3.4
-  ruby_2_4:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.4
 workflows:
   version: 2
   test:
     jobs:
       - ruby_2_2
       - ruby_2_3
-      - ruby_2_4


### PR DESCRIPTION
CircleCI shows persistent failure with regards to building the `json` rubygem: https://circleci.com/gh/facebook/taste-tester/118?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

I removed an explicit dependency on `json` in `between-meals` in https://github.com/facebook/between-meals/pull/83 In spite of this change, and with evidence of using the updated commit the build system continues to somehow pull in version `1.7.7` of `json` which is incompatible. I am unable to reproduce this outside of CircleCI so in the short term I am removing the invalid test.

I am open to an alternate route that does not involve chasing down a secondary dependency or digging deeply into CircleCI's mechanics.