### PR TITLE
taste-tester test race condition fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -120,10 +120,6 @@ Performance/RedundantMerge:
 Style/ConditionalAssignment:
   Enabled: false
 
-# Heredocs are fine with "EOF"
-Naming/HeredocDelimiterNaming:
-  Enabled: false
-
 # This double-reports what happens in EmptyLines
 Layout/EmptyLineBetweenDefs:
   Enabled: false
@@ -143,10 +139,7 @@ HashSyntax:
 Style/Documentation:
   Enabled: false
 
-TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-
-TrailingCommaInHashLiteral:
+TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
 TrailingCommaInArguments:
@@ -164,7 +157,7 @@ Style/SignalException:
 Style/NumericLiteralPrefix:
   Enabled: false
 
-Naming/VariableNumber:
+Style/VariableNumber:
   Enabled: false
 
 Style/RegexpLiteral:
@@ -178,12 +171,4 @@ Style/PercentLiteralDelimiters:
 
 # no, we're not putting parens around `lazy`
 Lint/AmbiguousBlockAssociation:
-  Enabled: false
-
-# we do this all over the place
-Style/MixinUsage:
-  Enabled: false
-
-# this is misfiring in multiple cookbooks
-Layout/EmptyLinesAroundArguments:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,7 +139,10 @@ HashSyntax:
 Style/Documentation:
   Enabled: false
 
-TrailingCommaInLiteral:
+TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 TrailingCommaInArguments:
@@ -157,7 +160,7 @@ Style/SignalException:
 Style/NumericLiteralPrefix:
   Enabled: false
 
-Style/VariableNumber:
+Naming/VariableNumber:
   Enabled: false
 
 Style/RegexpLiteral:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.4
   Exclude:
     # template files named `rb` instead of `erb` are a sin against ruby-nature.
     - '**/templates/**/*.rb'#

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.0.14
-* Always use the desired knife config (#87)
-* Return failure and partial failure on test (#88)
-* Fixed rubocop rules (#89)
-* Reduce example test time, inline with best security practices. (#91)
-* Eliminate race conditions in test (#92)
-
 ## 0.0.13
 * Add a NoOp transport
 * Replace `--locallink` with `--transport`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.14
+* Always use the desired knife config (#87)
+* Return failure and partial failure on test (#88)
+* Fixed rubocop rules (#89)
+* Reduce example test time, inline with best security practices. (#91)
+* Eliminate race conditions in test (#92)
+
 ## 0.0.13
 * Add a NoOp transport
 * Replace `--locallink` with `--transport`

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -419,4 +419,3 @@ MODES:
     include TasteTester
   end
 end
-

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -30,16 +30,16 @@ require 'taste_tester/commands'
 require 'taste_tester/hooks'
 require 'taste_tester/exceptions'
 
-include TasteTester::Logging
-
-if ENV['USER'] == 'root'
-  logger.warn('You should not be running as root')
-  exit(1)
-end
-
 # Command line parsing and param descriptions
 module TasteTester
+  include TasteTester::Logging
+
   verify = 'Verify your changes were actually applied as intended!'.red
+
+  if ENV['USER'] == 'root'
+    logger.warn('You should not be running as root')
+    exit(1)
+  end
 
   # Do an initial read of the config file if it's in the default place, so
   # that if people override chef_client_command the help message is correct.
@@ -50,7 +50,7 @@ module TasteTester
   end
 
   cmd = TasteTester::Config.chef_client_command
-  description = <<-EOF
+  description = <<-ENDOFDESCRIPTION
 Welcome to taste-tester!
 
 Usage: taste-tester <mode> [<options>]
@@ -120,7 +120,7 @@ MODES:
     You probably don't want this. It will restart up the chef-zero server on
     your localhost. taste-tester dynamically starts this if it's down, so there
     should be no need to do this manually.
-  EOF
+  ENDOFDESCRIPTION
 
   mode = ARGV.shift unless !ARGV.empty? && ARGV[0].start_with?('-')
 
@@ -414,8 +414,9 @@ MODES:
   rescue TasteTester::Exceptions::SshError
     exit(1)
   end
+
+  if $PROGRAM_NAME == __FILE__
+    include TasteTester
+  end
 end
 
-if $PROGRAM_NAME == __FILE__
-  include TasteTester
-end

--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook
@@ -66,7 +68,7 @@ module TasteTester
       unless TasteTester::Config.yes
         printf("Set #{TasteTester::Config.servers} to test mode? [y/N] ")
         ans = STDIN.gets.chomp
-        exit(1) unless ans =~ /^[yY](es)?$/
+        exit(1) unless ans.match?(/^[yY](es)?$/)
       end
       if TasteTester::Config.linkonly && TasteTester::Config.really
         logger.warn('Skipping upload at user request... potentially dangerous!')

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -19,6 +19,7 @@ require 'taste_tester/host'
 require 'taste_tester/config'
 require 'taste_tester/client'
 require 'taste_tester/logging'
+require 'taste_tester/exceptions'
 
 module TasteTester
   # Functionality dispatch
@@ -93,12 +94,11 @@ module TasteTester
       tested_hosts = []
       hosts.each do |hostname|
         host = TasteTester::Host.new(hostname, server)
-        if host.in_test?
-          username = host.who_is_testing
-          logger.error("User #{username} is already testing on #{hostname}")
-        else
+        begin
           host.test
           tested_hosts << hostname
+        rescue TasteTester::Exceptions::AlreadyTestingError => e
+          logger.error("User #{e.username} is already testing on #{hostname}")
         end
       end
       unless TasteTester::Config.skip_post_test_hook ||

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -118,11 +118,8 @@ module TasteTester
     end
 
     def self.testing_end_time
-      if TasteTester::Config.testing_until
-        TasteTester::Config.testing_until
-      else
+      TasteTester::Config.testing_until ||
         Time.now + TasteTester::Config.testing_time
-      end
     end
   end
 end

--- a/lib/taste_tester/exceptions.rb
+++ b/lib/taste_tester/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/exceptions.rb
+++ b/lib/taste_tester/exceptions.rb
@@ -22,5 +22,12 @@ module TasteTester
     end
     class NoOpError < StandardError
     end
+    class AlreadyTestingError < StandardError
+      attr_reader :username
+
+      def initialize(username)
+        @username = username
+      end
+    end
   end
 end

--- a/lib/taste_tester/hooks.rb
+++ b/lib/taste_tester/hooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook
@@ -113,9 +115,9 @@ module TasteTester
       transport << "tt=$(mktemp #{TasteTester::Config.chef_config_path}/" +
         "#{TASTE_TESTER_CONFIG}.TMPXXXXXX)"
       transport << "/bin/echo -n \"#{serialized_config}\" | base64 --decode" +
-        " > \"${tt}\""
+        ' > "${tt}"'
       # then rename it to replace any existing file
-      transport << "mv -f \"${tt}\" " +
+      transport << 'mv -f "${tt}" ' +
         "#{TasteTester::Config.chef_config_path}/#{TASTE_TESTER_CONFIG}"
       transport << "( ln -vsf #{TasteTester::Config.chef_config_path}" +
         "/#{TASTE_TESTER_CONFIG} #{TasteTester::Config.chef_config_path}/" +
@@ -130,10 +132,10 @@ module TasteTester
       case transport.status
       when 0
         # no problem, keep going.
+        nil
       when 42
-        raise TasteTester::Exceptions::AlreadyTestingError.new(
-          transport.output.chomp,
-        )
+        fail TasteTester::Exceptions::AlreadyTestingError,
+             transport.output.chomp
       else
         transport.error!
       end
@@ -226,7 +228,7 @@ module TasteTester
       if TasteTester::Config.use_ssh_tunnels
         url = "#{scheme}://localhost:#{@tunnel.port}"
       else
-        url = "#{scheme}://#{@server.host}"
+        url = +"#{scheme}://#{@server.host}"
         url << ":#{TasteTester::State.port}" if TasteTester::State.port
       end
       ttconfig = <<-EOS

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -31,7 +31,7 @@ module TasteTester
     include TasteTester::Logging
 
     TASTE_TESTER_CONFIG = 'client-taste-tester.rb'
-    USER_PREABLE = '# TasteTester by '
+    USER_PREAMBLE = '# TasteTester by '
 
     attr_reader :name
 
@@ -177,14 +177,14 @@ module TasteTester
       config_file = "#{TasteTester::Config.chef_config_path}/" +
         TasteTester::Config.chef_config
       # Look for signature of TasteTester
-      # 1. Look for USER_PREABLE line prefix
+      # 1. Look for USER_PREAMBLE line prefix
       # 2. See if user is us, or someone else
       # 3. if someone else is testing: emit username, exit with code 42 which
       #    short circuits the test verb
       # This is written as a squiggly heredoc so the indentation of the awk is
       # preserved. Later we remove the newlines to make it a bit easier to read.
       shellcode = <<~EOF
-        awk "\\$0 ~ /^#{USER_PREABLE}/{
+        awk "\\$0 ~ /^#{USER_PREAMBLE}/{
           if (\\$NF != \\"#{@user}\\"){
             print \\$NF;
             exit 42
@@ -230,7 +230,7 @@ module TasteTester
         url << ":#{TasteTester::State.port}" if TasteTester::State.port
       end
       ttconfig = <<-EOS
-#{USER_PREABLE}#{@user}
+#{USER_PREAMBLE}#{@user}
 # Prevent people from screwing up their permissions
 if Process.euid != 0
   puts 'Please run chef as root!'

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -111,13 +111,13 @@ module TasteTester
       transport << 'logger -t taste-tester Moving server into taste-tester' +
         " for #{@user}"
       transport << touchcmd
-      # shell redirection is also racey, so make a temporary file first
+      # shell redirection is also racy, so make a temporary file first
       transport << "tt=$(mktemp #{TasteTester::Config.chef_config_path}/" +
         "#{TASTE_TESTER_CONFIG}.TMPXXXXXX)"
       transport << "/bin/echo -n \"#{serialized_config}\" | base64 --decode" +
-        ' > "${tt}"'
+        ' > "${tempconfig}"'
       # then rename it to replace any existing file
-      transport << 'mv -f "${tt}" ' +
+      transport << 'mv -f "${tempconfig}" ' +
         "#{TasteTester::Config.chef_config_path}/#{TASTE_TESTER_CONFIG}"
       transport << "( ln -vsf #{TasteTester::Config.chef_config_path}" +
         "/#{TASTE_TESTER_CONFIG} #{TasteTester::Config.chef_config_path}/" +
@@ -248,17 +248,17 @@ module TasteTester
 
       extra = TasteTester::Hooks.test_remote_client_rb_extra_code(@name)
       if extra
-        ttconfig += <<-EOS
-# Begin user-hook specified code
-        #{extra}
-# End user-hook secified code
+        ttconfig += <<~ENDOFSCRIPT
+          # Begin user-hook specified code
+                  #{extra}
+          # End user-hook secified code
 
-        EOS
+        ENDOFSCRIPT
       end
 
-      ttconfig += <<-EOS
-puts 'INFO: Running on #{@name} in taste-tester by #{@user}'
-      EOS
+      ttconfig += <<~ENDOFSCRIPT
+        puts 'INFO: Running on #{@name} in taste-tester by #{@user}'
+      ENDOFSCRIPT
       return ttconfig
     end
   end

--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook
@@ -41,13 +43,13 @@ module TasteTester
 
     def run!
       @status, @output = exec!(cmd, logger)
-    rescue StandardError => e
+    rescue StandardError
       error!
     end
 
     def error!
       logger.error(e.message)
-      raise TasteTester::Exceptions::LocalLinkError
+      fail TasteTester::Exceptions::LocalLinkError
     end
 
     private

--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -42,6 +42,10 @@ module TasteTester
     def run!
       @status, @output = exec!(cmd, logger)
     rescue StandardError => e
+      error!
+    end
+
+    def error!
       logger.error(e.message)
       raise TasteTester::Exceptions::LocalLinkError
     end

--- a/lib/taste_tester/logging.rb
+++ b/lib/taste_tester/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook
@@ -58,7 +60,7 @@ module TasteTester
         end
       else
         proc do |severity, _datetime, _progname, msg|
-          msg.to_s.prepend("#{severity}: ") unless severity == 'WARN'
+          msg.dup.to_s.prepend("#{severity}: ") unless severity == 'WARN'
           if severity == 'ERROR'
             msg = msg.to_s.red
           end

--- a/lib/taste_tester/noop.rb
+++ b/lib/taste_tester/noop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/noop.rb
+++ b/lib/taste_tester/noop.rb
@@ -56,6 +56,10 @@ module TasteTester
       [0, "# TasteTester by #{@user}"]
     end
 
+    def error!
+      # never fails, but interface requires a definition
+    end
+
     private
 
     def cmd

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook
@@ -158,7 +160,7 @@ module TasteTester
         extend ::TasteTester::Windows
         start_win_chef_zero_server
       else
-        cmd = "#{chef_zero_path} --host #{@addr} --port #{@state.port} -d"
+        cmd = +"#{chef_zero_path} --host #{@addr} --port #{@state.port} -d"
         if TasteTester::Config.chef_zero_logging
           cmd << " --log-file #{@log_file}" +
             ' --log-level debug'

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -22,7 +22,7 @@ module TasteTester
     include TasteTester::Logging
     include BetweenMeals::Util
 
-    attr_reader :output
+    attr_reader :output, :status
 
     def initialize(host, timeout = 5, tunnel = false)
       @host = host
@@ -43,7 +43,11 @@ module TasteTester
 
     def run!
       @status, @output = exec!(cmd, logger)
-    rescue StandardError => e
+    rescue StandardError
+      error!
+    end
+
+    def error!
       error = <<-MSG
 SSH returned error while connecting to #{TasteTester::Config.user}@#{@host}
 The host might be broken or your SSH access is not working properly
@@ -52,7 +56,6 @@ Try doing
 and come back once that works
 MSG
       error.lines.each { |x| logger.error x.strip }
-      logger.error(e.message)
       raise TasteTester::Exceptions::SshError
     end
 

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook
@@ -56,7 +58,7 @@ Try doing
 and come back once that works
 MSG
       error.lines.each { |x| logger.error x.strip }
-      raise TasteTester::Exceptions::SshError
+      fail TasteTester::Exceptions::SshError
     end
 
     private

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -50,13 +50,13 @@ module TasteTester
     end
 
     def error!
-      error = <<-MSG
+      error = <<-ERRORMESSAGE
 SSH returned error while connecting to #{TasteTester::Config.user}@#{@host}
 The host might be broken or your SSH access is not working properly
 Try doing
   #{TasteTester::Config.ssh_command} -v #{TasteTester::Config.user}@#{@host}
 and come back once that works
-MSG
+      ERRORMESSAGE
       error.lines.each { |x| logger.error x.strip }
       fail TasteTester::Exceptions::SshError
     end

--- a/lib/taste_tester/state.rb
+++ b/lib/taste_tester/state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/windows.rb
+++ b/lib/taste_tester/windows.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.name = 'taste_tester'

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.name = 'taste_tester'
-  s.version = '0.0.13'
+  s.version = '0.0.14'
   s.homepage = 'https://github.com/facebook/taste-tester'
   s.platform = Gem::Platform::RUBY
   s.summary = 'Taste Tester'

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.name = 'taste_tester'
-  s.version = '0.0.14'
+  s.version = '0.0.13'
   s.homepage = 'https://github.com/facebook/taste-tester'
   s.platform = Gem::Platform::RUBY
   s.summary = 'Taste Tester'

--- a/test/tt-auto.rb
+++ b/test/tt-auto.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 chef_zero_path 'bundle exec chef-zero'
 repo '/tmp/ops'
 repo_type 'auto'

--- a/test/tt-git.rb
+++ b/test/tt-git.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 chef_zero_path 'bundle exec chef-zero'
 repo '/tmp/ops'
 repo_type 'git'

--- a/test/tt-hg.rb
+++ b/test/tt-hg.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 chef_zero_path 'bundle exec chef-zero'
 repo '/tmp/ops'
 repo_type 'hg'


### PR DESCRIPTION
Taste-tester was originally conceived as a tool for humans. Adding automation has highlighted issues when the same host is accidentally chosen. This already gives an error, explaining that someone else is testing

> Taste-testing on _hostname_
> ERROR: User someoneelse is already testing on _hostname_
> ERROR: Taste-testing failed. HOST NOT PUT IN TESTING MODE.

The existing code uses the transport (usually SSH) multiple times which is slow, and therefore more likely to hit a race condition. Current code:

1. Checks for timestamp file presence
2. greps for username in config
3. greps for username in config file to see if it matches the current user
4. Writes the new config file out

It could be up to 6 connections, if the legacy FB stuff for matching usernames was being used.

Instead of using transport 4-6 times, we use it once, and pile a bunch of sequential logic in to predicate the addition of the new config file only if the host isn't being tested by someone else. Once the files are
written, symlinks changed, we look again to see if we "won".

Additional items:

* Removed timestamp check when reading the config file for an existing user. If the current config file mentions a user, it will definitely still be taste-tested. This check didn't help anything.
* `chef_config_path` is now written to a temporary file then renamed which makes the contents atomic. Two simultaneous writes can produce garbage configuration.
* Removed most explicit `rm -f` before `ln -s`, replacing with `ln -sf` which according to POSIX specifications also unlinks but in the same command.
* Changed single quote/apostrophe from use of `serialized_config` to double quotes. The command is already run with single quotes via SSH so this was effectively *un*quoting the text, which is more dangerous than double quoting or leaving unquoted.
* `@serialized_config` is never used as a member variable, so demoted to a local instance variable
* Removed FB legacy username lookup from `who_is_testing`.
* Move test config filename into constant.
* Use constant for preable written, and matched.
* Whole stack of rubocop config changes, and updates to make the tests pass.