### PR TITLE
use chef_zero_running? to determine whether chef-zero is running

### DIFF
--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -57,6 +57,7 @@ module TasteTester
       unless @repo.exists?
         fail "Could not open repo from #{TasteTester::Config.repo}"
       end
+
       @track_symlinks = TasteTester::Config.track_symlinks
     end
 

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -31,6 +31,7 @@ module TasteTester
     def self.start
       server = TasteTester::Server.new
       return if TasteTester::Server.running?
+
       server.start
     end
 

--- a/lib/taste_tester/logging.rb
+++ b/lib/taste_tester/logging.rb
@@ -51,6 +51,7 @@ module TasteTester
 
     def formatter
       return @@formatter_proc if @@formatter_proc
+
       if @@use_log_formatter
         proc do |severity, datetime, _progname, msg|
           if severity == 'ERROR'

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -125,7 +125,8 @@ module TasteTester
 
     def self.running?
       if TasteTester::State.port
-        return chef_zero_running?(TasteTester::State.port)
+        return chef_zero_running?(TasteTester::State.port,
+                                  TasteTester::Config.use_ssl)
       end
 
       false

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -125,8 +125,9 @@ module TasteTester
 
     def self.running?
       if TasteTester::State.port
-        return port_open?(TasteTester::State.port)
+        return chef_zero_running?(TasteTester::State.port)
       end
+
       false
     end
 


### PR DESCRIPTION
Currently we're only checking whether the state file's port param has any process listening on it (via port_open?). This change utilizes a new helper (chef_zero_running?) to not only check that a process is listening on the port, but specifically a chef-zero proc.

Depends on https://github.com/facebook/between-meals/pull/92