### PR TITLE
README fix, plugin_path does not have a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ See the help for futher information.
 
 ## Prerequisites
 
-* Taste Tester assumes that /etc/chef/client.rb and /etc/chef/client.pem on your
-servers is a symlink and that your real config is /etc/chef/client-prod.rb and
-/etc/chef/client-prod.pem, respectively.
+* Taste Tester assumes that `/etc/chef/client.rb` and `/etc/chef/client.pem` on your
+servers is a symlink and that your real config is `/etc/chef/client-prod.rb` and
+`/etc/chef/client-prod.pem`, respectively.
 
 * Taste Tester assumes that it's generally safe to "go back" to production. I.e.
 We set things up so you can set a cronjob to un-taste-test a server after the
@@ -79,15 +79,14 @@ is also killing the ssh tunnel whose PID is in `/etc/chef/test_timestamp`
 ## Config file
 
 The default config file is `/etc/taste-tester-config.rb` but you may use -c to
-specify another. The config file works the same as client.rb does for Chef -
-there are a series of keywords that take an arguement and anything else is just
+specify another. The config file works the same as `client.rb` does for Chef -
+there are a series of keywords that take an argument and anything else is just
 standard Ruby.
 
 All command-line options are available in the config file:
 * debug (bool, default: `false`)
 * timestamp (bool, default: `false`)
 * config_file (string, default: `/etc/taste-tester-config.rb`)
-* plugin_path (string, default: `/etc/taste-tester-plugin.rb`)
 * repo (string, default: `#{ENV['HOME']}/ops`)
 * testing_time (int, default: `3600`)
 * chef_client_command (strng, default: `chef-client`)
@@ -106,6 +105,8 @@ The following options are also available:
 * role_dir - A directory of roles, relative to base_dir. Default: `roles`
 * databag_dir - A directory of databags, relative to base_dir.
   Default: `databags`
+* plugin_path - A ruby file containing plugin code to extend the functionality
+  of taste-tester, (e.g. `plugin_path /etc/taste-tester-plugin.rb`)
 * ref_file - The file to store the last git revision we uploaded in. Default:
   `#{ENV['HOME']}/.chef/taste-tester-ref.txt`
 * checksum_dir - The checksum directory to put in knife.conf for users. Default:
@@ -150,3 +151,18 @@ Stuff to do after putting all hosts in test mode.
 * self.repo_checks(dryrun, repo)
 
 Additional checks you want to do on the repo as sanity checks.
+
+**Plugin example**
+
+This is example code to add a user-defined string to `client-taste-tester.rb` on
+the remote system:
+```
+Hooks.class_eval do
+  def self.test_remote_client_rb_extra_code(_hostname)
+    %(
+      # This comment gets added to client-taste-tester.rb
+      # This one too.
+      )
+  end
+end
+```

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ All command-line options are available in the config file:
 * debug (bool, default: `false`)
 * timestamp (bool, default: `false`)
 * config_file (string, default: `/etc/taste-tester-config.rb`)
+* plugin_path (string, no default)
 * repo (string, default: `#{ENV['HOME']}/ops`)
 * testing_time (int, default: `3600`)
 * chef_client_command (strng, default: `chef-client`)
@@ -105,8 +106,6 @@ The following options are also available:
 * role_dir - A directory of roles, relative to base_dir. Default: `roles`
 * databag_dir - A directory of databags, relative to base_dir.
   Default: `databags`
-* plugin_path - A ruby file containing plugin code to extend the functionality
-  of taste-tester, (e.g. `plugin_path /etc/taste-tester-plugin.rb`)
 * ref_file - The file to store the last git revision we uploaded in. Default:
   `#{ENV['HOME']}/.chef/taste-tester-ref.txt`
 * checksum_dir - The checksum directory to put in knife.conf for users. Default:
@@ -154,8 +153,8 @@ Additional checks you want to do on the repo as sanity checks.
 
 **Plugin example**
 
-This is example code to add a user-defined string to `client-taste-tester.rb` on
-the remote system:
+This is an example `/etc/taste-tester-plugin.rb` to add a user-defined string
+to `client-taste-tester.rb` on the remote system:
 ```
 Hooks.class_eval do
   def self.test_remote_client_rb_extra_code(_hostname)
@@ -166,3 +165,5 @@ Hooks.class_eval do
   end
 end
 ```
+Be sure to pass this plugin file as `-p` on the command line or set it as 
+`plugin_path` in your `taste-tester-config.rb` file.

--- a/README.md
+++ b/README.md
@@ -165,5 +165,5 @@ Hooks.class_eval do
   end
 end
 ```
-Be sure to pass this plugin file as `-p` on the command line or set it as 
+Be sure to pass this plugin file with `-p` on the command line or set it as 
 `plugin_path` in your `taste-tester-config.rb` file.


### PR DESCRIPTION
* In the README, it says plugin_path has a default to /etc/taste-tester-plugin.rb :

`plugin_path (string, default: /etc/taste-tester-plugin.rb)`

but in code it's really set to`nil`: https://github.com/facebook/taste-tester/blob/master/lib/taste_tester/config.rb#L40

This PR updates README to say the command line flag has no default, but a suggested path is added in the plugin documentation.

(or should the code use a default plugin path instead?)

* Add a short example plugin (see also https://github.com/facebook/taste-tester/issues/82) to README
* Markdown fixes to add credibility to claims I contributed to an open-source project ;)