### PR TITLE
Remove ruby 2.2 from ci tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.2.2
   - 2.3.4
   - 2.4.0
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,10 +9,6 @@ defaults: &defaults
 
 version: 2
 jobs:
-  ruby_2_2:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.2
   ruby_2_3:
     <<: *defaults
     docker:
@@ -25,6 +21,5 @@ workflows:
   version: 2
   test:
     jobs:
-      - ruby_2_2
       - ruby_2_3
       - ruby_2_4


### PR DESCRIPTION
We are moving to more modern ruby, lets stop testing on rubies that aren't in chef