### PR TITLE
Remove frozen_string_literal magic comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source 'https://rubygems.org'
 
 gemspec

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/exceptions.rb
+++ b/lib/taste_tester/exceptions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/hooks.rb
+++ b/lib/taste_tester/hooks.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -30,8 +30,8 @@ module TasteTester
   class Host
     include TasteTester::Logging
 
-    TASTE_TESTER_CONFIG = 'client-taste-tester.rb'
-    USER_PREAMBLE = '# TasteTester by '
+    TASTE_TESTER_CONFIG = 'client-taste-tester.rb'.freeze
+    USER_PREAMBLE = '# TasteTester by '.freeze
 
     attr_reader :name
 

--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/logging.rb
+++ b/lib/taste_tester/logging.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/noop.rb
+++ b/lib/taste_tester/noop.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/state.rb
+++ b/lib/taste_tester/state.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/lib/taste_tester/windows.rb
+++ b/lib/taste_tester/windows.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
 # Copyright 2013-present Facebook

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Gem::Specification.new do |s|
   s.name = 'taste_tester'
   s.version = '0.0.13'

--- a/test/tt-auto.rb
+++ b/test/tt-auto.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 chef_zero_path 'bundle exec chef-zero'
 repo '/tmp/ops'
 repo_type 'auto'

--- a/test/tt-git.rb
+++ b/test/tt-git.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 chef_zero_path 'bundle exec chef-zero'
 repo '/tmp/ops'
 repo_type 'git'

--- a/test/tt-hg.rb
+++ b/test/tt-hg.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 chef_zero_path 'bundle exec chef-zero'
 repo '/tmp/ops'
 repo_type 'hg'


### PR DESCRIPTION
The inclusion of this comment without refactoring the code is resulting in a user's config failing to being written out or updated. We can add this back to the code once we have refactored and added the appropriate tests to validate functionality.