### PR TITLE
Add status accessor to noop, locallink modes

### DIFF
--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -22,7 +22,7 @@ module TasteTester
     include TasteTester::Logging
     include BetweenMeals::Util
 
-    attr_reader :output
+    attr_reader :output, :status
 
     def initialize
       @host = 'localhost'

--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -41,12 +41,12 @@ module TasteTester
 
     def run!
       @status, @output = exec!(cmd, logger)
-    rescue StandardError
+    rescue StandardError => e
+      logger.error(e.message)
       error!
     end
 
     def error!
-      logger.error(e.message)
       fail TasteTester::Exceptions::LocalLinkError
     end
 

--- a/lib/taste_tester/noop.rb
+++ b/lib/taste_tester/noop.rb
@@ -22,7 +22,7 @@ module TasteTester
     include TasteTester::Logging
     include BetweenMeals::Util
 
-    attr_reader :output
+    attr_reader :output, :status
 
     def initialize
       print_noop_warning
@@ -48,7 +48,7 @@ module TasteTester
     alias << add
 
     def run
-      run!
+      @status, @output = run!
     end
 
     def run!

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -43,8 +43,8 @@ module TasteTester
 
     def run!
       @status, @output = exec!(cmd, logger)
-    rescue StandardError, e
-      logger.exception(e)
+    rescue StandardError => e
+      logger.error(e.message)
       error!
     end
 

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -43,7 +43,8 @@ module TasteTester
 
     def run!
       @status, @output = exec!(cmd, logger)
-    rescue StandardError
+    rescue StandardError, e
+      logger.exception(e)
       error!
     end
 


### PR DESCRIPTION
Before:

```
/opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/lib/taste_tester/host.rb:130:in `test': undefined method `status' for #<TasteTester::NoOp:0x0000000000c3aac8> (NoMethodError)
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/lib/taste_tester/commands.rb:99:in `block in test'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/lib/taste_tester/commands.rb:96:in `each'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/lib/taste_tester/commands.rb:96:in `test'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/bin/taste-tester:400:in `<module:TasteTester>'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.13/bin/taste-tester:32:in `<top (required)>'
        from /opt/chefdk/embedded/bin/taste-tester:23:in `load'
        from /opt/chefdk/embedded/bin/taste-tester:23:in `<main>'
```

After:

*no error*