### PR TITLE
Add status addr to TasteTester::NoOp

### DIFF
--- a/lib/taste_tester/noop.rb
+++ b/lib/taste_tester/noop.rb
@@ -24,13 +24,14 @@ module TasteTester
     include TasteTester::Logging
     include BetweenMeals::Util
 
-    attr_reader :output
+    attr_reader :output, :status
 
     def initialize
       print_noop_warning
       @host = 'localhost'
       @user = ENV['USER']
       @cmds = []
+      @status = 0
     end
 
     def print_noop_warning


### PR DESCRIPTION
TasteTester::Host::test expects a transport status attr (https://github.com/facebook/taste-tester/blob/master/lib/taste_tester/host.rb#L130) which NoOp does not currently have.