### PR TITLE
Use return value of transport.run instead of status, output members

### DIFF
--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -125,15 +125,14 @@ module TasteTester
       # we work out if we won or lost a race with another user.
       transport << we_testing
 
-      transport.run
+      status, output = transport.run
 
-      case transport.status
+      case status
       when 0
         # no problem, keep going.
         nil
       when 42
-        fail TasteTester::Exceptions::AlreadyTestingError,
-             transport.output.chomp
+        fail TasteTester::Exceptions::AlreadyTestingError, output.chomp
       else
         transport.error!
       end

--- a/lib/taste_tester/locallink.rb
+++ b/lib/taste_tester/locallink.rb
@@ -22,8 +22,6 @@ module TasteTester
     include TasteTester::Logging
     include BetweenMeals::Util
 
-    attr_reader :output, :status
-
     def initialize
       @host = 'localhost'
       @cmds = []
@@ -36,11 +34,11 @@ module TasteTester
     alias << add
 
     def run
-      @status, @output = exec(cmd, logger)
+      exec(cmd, logger)
     end
 
     def run!
-      @status, @output = exec!(cmd, logger)
+      exec!(cmd, logger)
     rescue StandardError => e
       logger.error(e.message)
       error!

--- a/lib/taste_tester/noop.rb
+++ b/lib/taste_tester/noop.rb
@@ -22,8 +22,6 @@ module TasteTester
     include TasteTester::Logging
     include BetweenMeals::Util
 
-    attr_reader :output, :status
-
     def initialize
       print_noop_warning
       @host = 'localhost'
@@ -48,7 +46,7 @@ module TasteTester
     alias << add
 
     def run
-      @status, @output = run!
+      run!
     end
 
     def run!

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -22,8 +22,6 @@ module TasteTester
     include TasteTester::Logging
     include BetweenMeals::Util
 
-    attr_reader :output, :status
-
     def initialize(host, tunnel = false)
       @host = host
       @tunnel = tunnel
@@ -37,11 +35,11 @@ module TasteTester
     alias << add
 
     def run
-      @status, @output = exec(cmd, logger)
+      exec(cmd, logger)
     end
 
     def run!
-      @status, @output = exec!(cmd, logger)
+      exec!(cmd, logger)
     rescue StandardError => e
       logger.error(e.message)
       error!

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -36,7 +36,7 @@ module TasteTester
     def run
       @port = TasteTester::Config.tunnel_port
       logger.info("Setting up tunnel on port #{@port}")
-      @status, @output = exec!(cmd, logger)
+      exec!(cmd, logger)
     rescue StandardError => e
       logger.error "Failed bringing up ssh tunnel: #{e}"
       exit(1)


### PR DESCRIPTION
Was intended in PR 102, but it got merged before I could fix it.