### PR TITLE
Fix logging

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -32,7 +32,7 @@ require 'taste_tester/exceptions'
 
 # Command line parsing and param descriptions
 module TasteTester
-  include TasteTester::Logging
+  extend TasteTester::Logging
 
   verify = 'Verify your changes were actually applied as intended!'.red
 


### PR DESCRIPTION
We're failing to log anything in bin/taste-tester due to a NoMethodError caused by the Logging module being included and not extended.