### PR TITLE
Support overriding SSH ConnectTimeout through config

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -328,6 +328,12 @@ MODES:
       options[:ssh_command] = c
     end
 
+    opts.on(
+      '--ssh-connect-timeout TIMEOUT', 'SSH \'-o ConnectTimeout\' value'
+    ) do |c|
+      options[:ssh_connect_timeout] = c
+    end
+
     opts.on('--skip-repo-checks', 'Skip repository sanity checks') do
       options[:skip_repo_checks] = true
     end

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -51,6 +51,7 @@ module TasteTester
     timestamp_file '/etc/chef/test_timestamp'
     use_ssh_tunnels false
     ssh_command 'ssh'
+    ssh_connect_timeout 5
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -24,9 +24,8 @@ module TasteTester
 
     attr_reader :output, :status
 
-    def initialize(host, timeout = 5, tunnel = false)
+    def initialize(host, tunnel = false)
       @host = host
-      @timeout = timeout
       @tunnel = tunnel
       @cmds = []
     end
@@ -68,7 +67,8 @@ and come back once that works
       end
       cmds = @cmds.join(' && ')
       cmd = "#{TasteTester::Config.ssh_command} " +
-            "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
+            '-T -o BatchMode=yes ' +
+            "-o ConnectTimeout=#{TasteTester::Config.ssh_connect_timeout} " +
             "#{TasteTester::Config.user}@#{@host} "
       if TasteTester::Config.user != 'root'
         cc = Base64.encode64(cmds).delete("\n")

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -22,10 +22,9 @@ module TasteTester
 
     attr_reader :port
 
-    def initialize(host, server, timeout = 5)
+    def initialize(host, server)
       @host = host
       @server = server
-      @timeout = timeout
       if TasteTester::Config.testing_until
         @delta_secs = TasteTester::Config.testing_until.strftime('%s').to_i -
                       Time.now.strftime('%s').to_i
@@ -58,7 +57,8 @@ module TasteTester
       # in a way that port was still open, but subsequent requests were hanging.
       # This is reproducible and should be looked into.
       cmd = "#{TasteTester::Config.ssh_command} " +
-            "-T -o BatchMode=yes -o ConnectTimeout=#{@timeout} " +
+            "-o ConnectTimeout=#{TasteTester::Config.ssh_connect_timeout} " +
+            '-T -o BatchMode=yes ' +
             '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' +
             "-o ServerAliveInterval=10 -o ServerAliveCountMax=#{@max_ping} " +
             "-f -R #{@port}:localhost:#{@server.port} "


### PR DESCRIPTION
ssh.rb/tunnel.rb have hard coded 5 seconds as ConnectTimeout

Move this value to config

Tested this by replacing ssh command (`-e`) with something that logs ssh executions, seen `-o ConnectTimeout` change when changing the `--ssh-connect-timeout` flag; Also, saw the previous default (5) when not specifying the `--ssh-connect-timeout` option