### PR TITLE
Include error message when tunnel setup fails

### DIFF
--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -38,8 +38,8 @@ module TasteTester
       @port = TasteTester::Config.tunnel_port
       logger.info("Setting up tunnel on port #{@port}")
       @status, @output = exec!(cmd, logger)
-    rescue StandardError
-      logger.error 'Failed bringing up ssh tunnel'
+    rescue StandardError => e
+      logger.error "Failed bringing up ssh tunnel: #{e}"
       exit(1)
     end
 


### PR DESCRIPTION
Include error message when tunnel setup fails in order to ease troubleshooting.