### PR TITLE
Support `bundle` mode with tar transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ you want to test on, i.e. SSH public/private keys, SSH certificates, Kerberos
 * Mixlib::Config
 * Colorize
 * BetweenMeals
+* Minitar
 
 ## Automatic Untesting
 
@@ -110,6 +111,10 @@ The following options are also available:
   `#{ENV['HOME']}/.chef/taste-tester-ref.txt`
 * checksum_dir - The checksum directory to put in knife.conf for users. Default:
   `#{ENV['HOME']}/.chef/checksums`
+* bundle - use a single tar.gz file for transporting cookbooks, roles and
+  databags to clients. Experimental.
+  Default: false
+
 
 ## Plugin
 

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -37,6 +37,7 @@ module TasteTester
     config_file '/etc/taste-tester-config.rb'
     plugin_path nil
     chef_zero_path nil
+    bundle false
     verbosity Logger::WARN
     timestamp false
     user 'root'

--- a/lib/taste_tester/state.rb
+++ b/lib/taste_tester/state.rb
@@ -91,6 +91,14 @@ module TasteTester
       write(:last_upload_time, time)
     end
 
+    def bundle
+      TasteTester::State.read(:bundle)
+    end
+
+    def bundle=(bundle)
+      write(:bundle, bundle)
+    end
+
     def update(vals)
       merge(vals)
     end

--- a/lib/taste_tester/windows.rb
+++ b/lib/taste_tester/windows.rb
@@ -40,6 +40,7 @@ module TasteTester
         cmd << " --log-file #{@log_file} --log-level debug"
       end
       cmd << ' --ssl' if TasteTester::Config.use_ssl
+      cmd << " --file-store #{@fsroot}" if TasteTester::Config.bundle
 
       # Mixlib::Shellout will always wait for a process to finish before
       # returning, so we use `spawn` instead.

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -41,5 +41,6 @@ Gem::Specification.new do |s|
   }.each do |dep|
     s.add_development_dependency dep
   end
+  s.add_dependency 'minitar', '>= 0.6.1'
   s.add_development_dependency 'rubocop', '= 0.49.1'
 end


### PR DESCRIPTION
Regular taste-tester uses chef-zero directly with knife upload. This has two issues:

1. The chef-client downloads resources one at a time. i.e. each file in a cookbook, each role, etc. This leads to a thundering herd of tiny transactions when taste-testing > 100 hosts in parallel.
2. knife upload is very slow for a large number of cookbook. The cold upload speed for cookbooks is around 1 minute 20s which is significant when given a deadline for testing changes.

This PR adds a new mode where the same chef-zero instance is used, but as a dumb web-server for a single file. This single file is created from the same list of cookbooks, roles and databags as knife would use. 

A single file is much easier to serve: in preliminary benchmarks, the WEBrick backend to chef-zero handles a few, larger downloads much better than a lot of tiny files, especially with TLS.

As this is creating an archive, this only works in a 'full upload' way - there's no distinct advantage to a partial upload. The same set of data that took 1 minute 20s to upload now takes about 1.8s. This is actually a little faster than using between-meals to produce a delta.

The target host's `client.rb` is modified to enable `solo` and `local_mode`, and the `chef_repo_path` is pointed at a temporary `/run/chef/taste-tester` directory. curl + tar are used to download the cookbooks+roles+databags on each run.