### PR TITLE
Use chdir in block mode to restore pwd

### DIFF
--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -132,44 +132,45 @@ module TasteTester
       return unless File.directory?(full_path)
       # everything is relative to the repo dir. chdir makes handling all the
       # paths within this simpler
-      Dir.chdir(full_path)
-      Find.find('.') do |p|
-        # ignore current directory. The File.directory? would also skip it,
-        # but we need to do it early because the string is too short for the
-        # next statement.
-        next if p == '.'
-        # paths are enumerated as relative to the input path '.', so we get
-        # './dir/file'. Stripping off the first two characters gives us a
-        # a cleaner 'dir/file' path.
-        name = File.join(destination, p[2..-1])
-        if File.directory?(p)
-          # skip it. This also handles symlinks to directories which aren't
-          # useful either.
-        elsif File.symlink?(p)
-          # tar handling of filenames > 100 characters gets complex. We'd use
-          # split_name from Minitar, but it's a private method. It's
-          # reasonable to assume that all symlink names in the bundle are
-          # less than 100 characters long. Long term, the version of minitar
-          # in chefdk should be upgraded.
-          fail 'Add support for long symlink paths' if name.size > 100
-          # The version of Minitar included in chefdk does not support
-          # symlinks directly. Therefore we use direct writes to the
-          # underlying stream to reproduce the symlinks
-          symlink = {
-            :name => name,
-            :mode => 0644,
-            :typeflag => '2',
-            :size => 0,
-            :linkname => File.readlink(p),
-            :prefix => '',
-          }
-          stream.write(Minitar::PosixHeader.new(symlink))
-        else
-          File.open(p, 'rb') do |r|
-            writer.add_file_simple(
-              name, :mode => 0644, :size => File.size(r)
-            ) do |d, _opts|
-              IO.copy_stream(r, d)
+      Dir.chdir(full_path) do
+        Find.find('.') do |p|
+          # ignore current directory. The File.directory? would also skip it,
+          # but we need to do it early because the string is too short for the
+          # next statement.
+          next if p == '.'
+          # paths are enumerated as relative to the input path '.', so we get
+          # './dir/file'. Stripping off the first two characters gives us a
+          # a cleaner 'dir/file' path.
+          name = File.join(destination, p[2..-1])
+          if File.directory?(p)
+            # skip it. This also handles symlinks to directories which aren't
+            # useful either.
+          elsif File.symlink?(p)
+            # tar handling of filenames > 100 characters gets complex. We'd use
+            # split_name from Minitar, but it's a private method. It's
+            # reasonable to assume that all symlink names in the bundle are
+            # less than 100 characters long. Long term, the version of minitar
+            # in chefdk should be upgraded.
+            fail 'Add support for long symlink paths' if name.size > 100
+            # The version of Minitar included in chefdk does not support
+            # symlinks directly. Therefore we use direct writes to the
+            # underlying stream to reproduce the symlinks
+            symlink = {
+              :name => name,
+              :mode => 0644,
+              :typeflag => '2',
+              :size => 0,
+              :linkname => File.readlink(p),
+              :prefix => '',
+            }
+            stream.write(Minitar::PosixHeader.new(symlink))
+          else
+            File.open(p, 'rb') do |r|
+              writer.add_file_simple(
+                name, :mode => 0644, :size => File.size(r)
+              ) do |d, _opts|
+                IO.copy_stream(r, d)
+              end
             end
           end
         end


### PR DESCRIPTION
Passing a relative repo path like `--repo .` caused the program to lose it's place. Using chdir in a block restores the previous working directory each time so this is safer.

Signed-off-by: Matthew Almond <malmond@fb.com>