### PR TITLE
Handle non-v6 environments

### DIFF
--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -65,10 +65,10 @@ module TasteTester
       # on all addresses - both v4 and v6. Note that on localhost, ::1 is
       # v6-only, so we default to 127.0.0.1 instead.
       if TasteTester::Config.use_ssh_tunnels
-        @addr = '127.0.0.1'
+        @addrs = ['127.0.0.1']
         @host = 'localhost'
       else
-        @addr = '::'
+        @addrs = ['::', '0.0.0.0']
         begin
           @host = TasteTester::Config.my_hostname || Socket.gethostname
         rescue StandardError
@@ -175,7 +175,8 @@ module TasteTester
         extend ::TasteTester::Windows
         start_win_chef_zero_server
       else
-        cmd = +"#{chef_zero_path} --host #{@addr} --port #{@state.port} -d"
+        hostarg = @addrs.map { |addr| "--host #{addr}" }.join(' ')
+        cmd = +"#{chef_zero_path} #{hostarg} --port #{@state.port} -d"
         if TasteTester::Config.chef_zero_logging
           cmd << " --log-file #{@log_file}" +
             ' --log-level debug'


### PR DESCRIPTION
Everyone has a v6 address these days - localhost. But not everyone has
a real v6 address. If that's the case, the existing code doesn't work.

There's some uglywork arounds, but we never fixed this properly because
chef-zero didn't support multiple `--host` arguments at the time.

That's not been the case for a long time, so this should work now.

FB: be sure to make sure the chef-zero in chefdk2 has this. I'm 99% sure
it does, but I don't wanna break you.

Signed-off-by: Phil Dibowitz <phil@ipom.com>