### PR TITLE
Ignore .swp files in tgz

### DIFF
--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -138,6 +138,10 @@ module TasteTester
           # but we need to do it early because the string is too short for the
           # next statement.
           next if p == '.'
+          # Overdelivering files is a problem in some cases: attributes,
+          # libraries end up enumerating and evaluating all files. If using
+          # vi(m) the swap file will be mistakenly opened.
+          next if p.end_with?('.swp')
           # paths are enumerated as relative to the input path '.', so we get
           # './dir/file'. Stripping off the first two characters gives us a
           # a cleaner 'dir/file' path.


### PR DESCRIPTION
These end up breaking chef client if present. This can happen if actively editing files in attributes for example.

This implementation is a stop gap until I can identify the code in knife or chef that enumerates cookbooks and role directories in a stricter way.

= Before

```
[2019-08-15T08:37:14-07:00] FATAL: Chef::Exceptions::AttributeNotFound: could not find filename for attribute .default.rb.swp in cookbook fb_init
```

= After

Taste-tested host runs chef correctly.

Signed-off-by: Matthew Almond <malmond@fb.com>