### PR TITLE
Improve transition of bundle mode with intermediate state

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ The following options are also available:
 * checksum_dir - The checksum directory to put in knife.conf for users. Default:
   `#{ENV['HOME']}/.chef/checksums`
 * bundle - use a single tar.gz file for transporting cookbooks, roles and
-  databags to clients. Experimental.
+  databags to clients. Experimental. Value is tri-state:
+  * `false` - server uses knife upload, client uses `chef_server`
+  * `:compatible` - make server support both methods, client uses tar.gz
+  * `true` - server only creates tar.gz, client uses tar.gz
   Default: false
 * impact - analyze local changes to determine which hosts/roles to test.
   Default: false

--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -210,11 +210,12 @@ module TasteTester
     end
 
     def full
+      logger.warn('Doing full upload')
       if TasteTester::Config.bundle
         bundle_upload
-        return
+        # only leave early if true (strictly bundle mode only)
+        return if TasteTester::Config.bundle == true
       end
-      logger.warn('Doing full upload')
       @knife.cookbook_upload_all
       @knife.role_upload_all
       @knife.databag_upload_all
@@ -224,7 +225,7 @@ module TasteTester
       if TasteTester::Config.bundle
         logger.info('No partial support for bundle mode, doing full upload')
         bundle_upload
-        return
+        return if TasteTester::Config.bundle == true
       end
       logger.info('Doing differential upload from ' +
                    @server.latest_uploaded_ref)

--- a/lib/taste_tester/state.rb
+++ b/lib/taste_tester/state.rb
@@ -91,7 +91,10 @@ module TasteTester
     end
 
     def bundle
-      TasteTester::State.read(:bundle)
+      val = TasteTester::State.read(:bundle)
+      # promote value to symbol to match config value.
+      return :compatible if val == 'compatible'
+      val
     end
 
     def bundle=(bundle)


### PR DESCRIPTION
Bundle mode does two things:

1. It improves client download times by using a single tgz bundle file
2. It improves server speed by avoiding using knife, et al to upload cookbooks. It just creates/replaces the tgz.

The problem happens when you use taste-tester in different locations.
At Facebook we allow for taste-tester to be used during server
provisioning. The flow there is that a *different* instance of taste-tester is run on the target against itself, and passes the `-m` / `--my-hostname` option to link to the named instance. The state of bundle mode can be different between these. For the duration of testing changing the default, use the new `:compatible` value which means the server will create a tgz *and* will continue to use `knife upload` et al.

Signed-off-by: Matthew Almond <malmond@fb.com>