### PR TITLE
Use chefignores logic in bundle mode

### DIFF
--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   %w{
     mixlib-config
     colorize
+    chef
   }.each do |dep|
     s.add_dependency dep
   end


### PR DESCRIPTION
This uses existing chefignore mechanics. This looks in both the directory specified, and in it's parent which is useful because cookbooks at Facebook are stored in more than one directory and multiple paths are configured. The chefignore is in the parent.

The practical upshot is that chefignore is honored. This includes patterns for all common backups, documentation, and things like `spec/*` which stops these being "uploaded" into the tarball.

Signed-off-by: Matthew Almond <malmond@fb.com>