### PR TITLE
Excise 'run' verb

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -39,15 +39,6 @@ module TasteTester
     exit(1)
   end
 
-  # Do an initial read of the config file if it's in the default place, so
-  # that if people override chef_client_command the help message is correct.
-  if File.exists?(File.expand_path(TasteTester::Config.config_file))
-    TasteTester::Config.from_file(
-      File.expand_path(TasteTester::Config.config_file),
-    )
-  end
-
-  cmd = TasteTester::Config.chef_client_command
   description = <<-ENDOFDESCRIPTION
 Welcome to taste-tester!
 
@@ -57,16 +48,18 @@ TLDR; Most common usage is:
   vi cookbooks/...              # Make your changes and commit locally
   taste-tester test -s [host]   # Put host in test mode
   ssh root@[host]               # Log on host
-  #{format('%-28s', "  #{cmd}")}  # Run chef and watch it break
+    # Run chef and watch it break
   vi cookbooks/...              # Fix your cookbooks
   taste-tester upload           # Upload the diff
   ssh root@[host]               # Log on host
-  #{format('%-28s', "  #{cmd}")}  # Run chef and watch it succeed
+    # Run chef and watch it succeed
   <#{verify}>
   taste-tester untest -s [host] # Put host back in production
                                 #   (optional - will revert itself after 1 hour)
 
-And you're done! See the above wiki page for more details.
+And you're done!
+Note: There may be site specific changes, e.g. instead of chef-client you may
+use a wrapper. See local documentation for details.
 
 MODES:
   test
@@ -106,11 +99,6 @@ MODES:
 
   status
     Print out the state of the world.
-
-  run
-    Run #{cmd} on the machine specified by '-s' over SSH and print the output.
-    NOTE!! This is #{'NOT'.red} a sufficient test, you must log onto the remote
-    machine and verify the changes you are trying to make are actually present.
 
   stop
     You probably don't want this. It will shutdown the chef-zero server on
@@ -430,8 +418,6 @@ MODES:
       TasteTester::Commands.test
     when :untest
       TasteTester::Commands.untest
-    when :run
-      TasteTester::Commands.runchef
     when :upload
       TasteTester::Commands.upload
     when :impact

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -149,19 +149,6 @@ module TasteTester
       end
     end
 
-    def self.runchef
-      hosts = TasteTester::Config.servers
-      unless hosts
-        logger.warn('You must provide a hostname')
-        exit(1)
-      end
-      server = TasteTester::Server.new
-      hosts.each do |hostname|
-        host = TasteTester::Host.new(hostname, server)
-        host.run
-      end
-    end
-
     def self.keeptesting
       hosts = TasteTester::Config.servers
       unless hosts

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -45,7 +45,6 @@ module TasteTester
     knife_config "#{ENV['HOME']}/.chef/knife-#{ENV['USER']}-taste-tester.rb"
     checksum_dir "#{ENV['HOME']}/.chef/checksums"
     skip_repo_checks false
-    chef_client_command 'chef-client'
     testing_time 3600
     chef_port_range [5000, 5500]
     tunnel_port 4001

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -44,38 +44,6 @@ module TasteTester
       end
     end
 
-    def runchef
-      logger.warn("Running '#{TasteTester::Config.chef_client_command}' " +
-                  "on #{@name}")
-      cmd = "#{TasteTester::Config.ssh_command} " +
-            "#{TasteTester::Config.user}@#{@name} "
-      if TasteTester::Config.user != 'root'
-        cc = Base64.encode64(cmds).delete("\n")
-        cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""
-      else
-        cmd += "\"#{cmds}\""
-      end
-      status = IO.popen(
-        cmd,
-      ) do |io|
-        # rubocop:disable AssignmentInCondition
-        while line = io.gets
-          puts line.chomp!
-        end
-        # rubocop:enable AssignmentInCondition
-        io.close
-        $CHILD_STATUS.to_i
-      end
-      logger.warn("Finished #{TasteTester::Config.chef_client_command}" +
-                  " on #{@name} with status #{status}")
-      if status.zero?
-        msg = "#{TasteTester::Config.chef_client_command} was successful" +
-              ' - please log to the host and confirm all the intended' +
-              ' changes were made'
-        logger.error msg.upcase
-      end
-    end
-
     def get_transport
       case TasteTester::Config.transport
       when 'locallink'


### PR DESCRIPTION
This has not worked in a *long time*. Today it produces an error like this:

```
/opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.14/lib/taste_tester/commands.rb:161:in `block in runchef': undefined method `run' for #<TasteTester::Host:0x000000000137de70> (NoMethodError)
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.14/lib/taste_tester/commands.rb:159:in `each'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.14/lib/taste_tester/commands.rb:159:in `runchef'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.14/bin/taste-tester:434:in `<module:TasteTester>'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/taste_tester-0.0.14/bin/taste-tester:32:in `<top (required)>'
        from /opt/chefdk/embedded/bin/taste-tester:23:in `load'
        from /opt/chefdk/embedded/bin/taste-tester:23:in `<main>'
```

There's two paths here:

1. Fix it.
2. Remove it.

I am chosing 2. because any form of meaningful testing involves getting an interactive shell on the target to compare the before to after state.  If you are doing this, you are in a position to run the chef-client interactively, possibly through a wrapper. I am erring on the side of removing dead code.

The name of the chef client command was never used. The help output was adjusted to use site specific values. Now we add the caveat to check local documentation for the exact invocation needed.

Signed-off-by: Matthew Almond <malmond@fb.com>