### PR TITLE
Update error message to facilitate  debugging

### DIFF
--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -51,7 +51,9 @@ SSH returned error while connecting to #{TasteTester::Config.user}@#{@host}
 The host might be broken or your SSH access is not working properly
 Try doing
   #{TasteTester::Config.ssh_command} -v #{TasteTester::Config.user}@#{@host}
-and come back once that works
+to see if ssh connection is good.
+If ssh works, add '-v' key to taste-tester to see the list of commands it's
+trying to execute, and try to run them manually on destination host
       ERRORMESSAGE
       error.lines.each { |x| logger.error x.strip }
       fail TasteTester::Exceptions::SshError


### PR DESCRIPTION
Summary: When taste tester has hard time to run remote commands, it's not limited to
ssh scope. Update message with debug instuctions

Test Plan:
Ran on effected host and got:
```
STDERR: Permission denied (publickey,keyboard-interactive).
SSH returned error while connecting to root@1405.<domain>
The host might be broken or your SSH access is not working properly
Try doing
ssh -v root@1405.od.fbinfra.net
to see if ssh connection is good.
If ssh works, add '-v' key to taste-tester to see the list of commands it's
trying to execute, and try to run them manually on destination host
ERROR: Taste-testing failed. HOST NOT PUT IN TESTING MODE.
```