### PR TITLE
Add jumphost support

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -293,6 +293,17 @@ MODES:
       options[:roles] = roles
     end
 
+    opts.on(
+      '-J', '--jumps JUMP',
+      'Uses ssh\'s `ProxyJump` support to ssh across bastion/jump hosts. ' +
+      'This is particularly useful in tunnel mode to test machines that ' +
+      'your workstatation doesn\'t have direct access to. The format is ' +
+      'the same as `ssh -J`: a comma-separated list of hosts to forward ' +
+      'through.'
+    ) do |jumps|
+      options[:jumps] = jumps
+    end
+
     opts.on('--really', 'Really do link-only. DANGEROUS!') do |r|
       options[:really] = r
     end

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -61,6 +61,7 @@ module TasteTester
     transport 'ssh'
     no_repo false
     json false
+    jumps nil
 
     # Start/End refs for calculating changes in the repo.
     #  - start_ref should be the "master" commit of the repository

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -66,7 +66,8 @@ trying to execute, and try to run them manually on destination host
         logger.info("Will run: '#{cmd}' on #{@host}")
       end
       cmds = @cmds.join(' && ')
-      cmd = "#{TasteTester::Config.ssh_command} " +
+      jumps = TasteTester::Config.jumps ? "-J #{TasteTester::Config.jumps}" : ''
+      cmd = "#{TasteTester::Config.ssh_command} #{jumps} " +
             '-T -o BatchMode=yes ' +
             "-o ConnectTimeout=#{TasteTester::Config.ssh_connect_timeout} " +
             "#{TasteTester::Config.user}@#{@host} "

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -56,7 +56,8 @@ module TasteTester
       # In most cases the first request from chef was "breaking" the tunnel,
       # in a way that port was still open, but subsequent requests were hanging.
       # This is reproducible and should be looked into.
-      cmd = "#{TasteTester::Config.ssh_command} " +
+      jumps = TasteTester::Config.jumps ? "-J #{TasteTester::Config.jumps}" : ''
+      cmd = "#{TasteTester::Config.ssh_command} #{jumps} " +
             "-o ConnectTimeout=#{TasteTester::Config.ssh_connect_timeout} " +
             '-T -o BatchMode=yes ' +
             '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' +


### PR DESCRIPTION
This PR adds the ability for taste-tester to jump through various
intermediate hosts to get to the testing host. It leverages ssh's
`ProxyJump` feature which means it fully supports the reverse-tunnel
through all layers.

Signed-off-by: Phil Dibowitz <phil@vicarious.com>