### PR TITLE
More robust SSH tunnel handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.3.4
   - 2.4.0
+  - 2.5.3
+  - 2.6.1
 
 gemfile:
   - Gemfile

--- a/circle.yml
+++ b/circle.yml
@@ -16,14 +16,15 @@ jobs:
   ruby_2_5:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.5
   ruby_2_6:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.6
 workflows:
   version: 2
   test:
     jobs:
-      - ruby_2_3
       - ruby_2_4
+      - ruby_2_5
+      - ruby_2_6

--- a/lib/taste_tester/server.rb
+++ b/lib/taste_tester/server.rb
@@ -16,7 +16,6 @@
 
 require 'fileutils'
 require 'socket'
-require 'timeout'
 
 require 'between_meals/util'
 require 'taste_tester/config'

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -76,11 +76,12 @@ trying to execute, and try to run them manually on destination host
       cmd = "#{ssh_base_cmd} -T -o BatchMode=yes " +
             "-o ConnectTimeout=#{TasteTester::Config.ssh_connect_timeout} " +
             "#{TasteTester::Config.user}@#{@host} "
+      cc = Base64.encode64(cmds).delete("\n")
+      cmd += "\"echo '#{cc}' | base64 --decode"
       if TasteTester::Config.user != 'root'
-        cc = Base64.encode64(cmds).delete("\n")
-        cmd += "\"echo '#{cc}' | base64 --decode | sudo bash -x\""
+        cmd += ' | sudo bash -x"'
       else
-        cmd += "\'#{cmds}\'"
+        cmd += ' | bash -x"'
       end
       cmd
     end

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.files = %w{README.md LICENSE} + Dir.glob('lib/taste_tester/*.rb') +
             Dir.glob('bin/*') + Dir.glob('scripts/*')
   s.executables = 'taste-tester'
-  s.license = 'Apache'
+  s.license = 'Apache-2.0'
   s.add_dependency 'between_meals', '>= 0.0.6'
   # without an explicit dependency, json is resolved to 1.7.7 on Ruby 2.4
   # which doesn't compile.


### PR DESCRIPTION
**Summary**

This is based off of https://github.com/facebook/taste-tester/pull/110 .
It has the same basic idea, but is tested and fixes a variety of bugs
both with that PR and with existing code.

The changes are as follows:
* Use HEREDOCs for the embedded shell so we don't have nested-quotes,
  which is easier to read and less error prone
* Stick some optional logging inside the shell so we know when and why
  tunnels are getting turn down
* The tunnel was never able to be killed by `untest` because we were
  jamming a sudo, but the whole thing is run in sudo so we were getting
  `sudo bash -c sudo kill -9 -- -<pid>` which wasn't working. Removing
  the redundant sudo fixed that
* We weren't going high enough the PID-chain to get SSH. Now we are:
    ```
    [phil@scale-lists1 ~]$ cat /etc/chef/test_timestamp
    14144
    [phil@scale-lists1 ~]$ ps -ef | grep 14144
    root     14144  1322  0 02:30 ?        00:00:00 sshd: phil [priv]
    phil     14152 14144  0 02:30 ?        00:00:00 sshd: phil@notty
    phil     15543 31390  0 02:34 pts/1    00:00:00 grep --color=auto 14144
    ````
* The license was typo'd and gem was bitching about it being an invalid
    license
* rugged doens't build on ruby 2.3, so dropped it

It's got some nice logging now that you'll see in the test plan

**Test Plan**

* When I remove the timestamp:
    ```
    May 21 01:54:47 scale-lists1 taste-tester: Ending tunnel: timestamp file disappeared
    ```
* When I change the PID in the timestamp:
    ```
    May 21 01:56:02 scale-lists1 taste-tester: Ending tunnel: timestamp PGID changed
    ```
* When I taste-untest the sshd process goes away

Tested with both root and non-root users, extensively