### PR TITLE
Update ruby tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,11 +9,15 @@ defaults: &defaults
 
 version: 2
 jobs:
-  ruby_2_3:
+  ruby_2_4:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.3.4
-  ruby_2_4:
+      - image: circleci/ruby:2.4
+  ruby_2_5:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.4
+  ruby_2_6:
     <<: *defaults
     docker:
       - image: circleci/ruby:2.4


### PR DESCRIPTION
Rugged doesn't build on 2.3 anymore. Drop it and add 2.5 and 2.6