### PR TITLE
Remove TravisCI badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Taste Tester
 
-[![TravisCI](https://travis-ci.org/facebook/taste-tester.svg)](http://travis-ci.org/facebook/taste-tester)
 [![CircleCI](https://circleci.com/gh/facebook/taste-tester.svg?style=svg)](https://circleci.com/gh/facebook/taste-tester)
 
 ## Intro


### PR DESCRIPTION
Noticed when #135 was merged, the badge was still there. Whoops!