### PR TITLE
First whack at windows (target) support for taste-tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 mkmf.log
 bin/
 sbin/
+.rubocop-https*

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -244,10 +244,13 @@ MODES:
       'Until when should the host remain in testing.' +
       ' Anything parsable is ok, such as "5/18 4:35" or "16/9/13".'
     ) do |time|
-      options[:testing_until] = Time.parse(time)
-    rescue StandardError
-      logger.error("Invalid date: #{time}")
-      exit 1
+      # can make this an implicit rescue after we drop ruby 2.4
+      begin
+        options[:testing_until] = Time.parse(time)
+      rescue StandardError
+        logger.error("Invalid date: #{time}")
+        exit 1
+      end
     end
 
     opts.on(
@@ -363,6 +366,15 @@ MODES:
       ' Default to false. Works on impact.'
     ) do
       options[:json] = true
+    end
+
+    opts.on(
+      '-w', '--windows-target',
+      'The target is a Windows machine. You will likely want to override ' +
+      '`test_timestamp` and `chef_config_path`, but *not* `config_file`. ' +
+      'Requires the target be running PowerShell >= 5.1 as the default shell.'
+    ) do
+      options[:windows_target] = true
     end
 
     opts.separator ''

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -63,6 +63,7 @@ module TasteTester
     no_repo false
     json false
     jumps nil
+    windows_target false
 
     # Start/End refs for calculating changes in the repo.
     #  - start_ref should be the "master" commit of the repository

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -1,0 +1,127 @@
+module TasteTester
+  class SSH
+    module Util
+      def ssh_base_cmd
+        jumps = TasteTester::Config.jumps ?
+          "-J #{TasteTester::Config.jumps}" : ''
+        "#{TasteTester::Config.ssh_command} #{jumps} -T -o BatchMode=yes " +
+          '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' +
+          "-o ConnectTimeout=#{TasteTester::Config.ssh_connect_timeout} " +
+          "#{TasteTester::Config.user}@#{@host} "
+      end
+
+      def error!
+        error = <<~ERRORMESSAGE
+  SSH returned error while connecting to #{TasteTester::Config.user}@#{@host}
+  The host might be broken or your SSH access is not working properly
+  Try doing
+
+      #{ssh_base_cmd} -v
+
+  to see if ssh connection is good.
+  If ssh works, add '-v' key to taste-tester to see the list of commands it's
+  trying to execute, and try to run them manually on destination host
+        ERRORMESSAGE
+        logger.error(error)
+        fail TasteTester::Exceptions::SshError
+      end
+
+      def build_ssh_cmd(ssh, command_list)
+        if TasteTester::Config.windows_target
+          # Powershell has no `&&`. So originally we looked into joining the
+          # various commands with `; if ($LASTEXITCODE -ne 0) { exit 42 }; `
+          # except that it turns out lots of Powershell commands don't set
+          # $LASTEXITCODE and so that crashes a lot.
+          #
+          # There is an `-and`, but it only works if you group things together
+          # with `()`, but that loses any output.
+          #
+          # Technically in the latest preview of Powershell 7, `&&` exists, but
+          # we cannot rely on this.
+          #
+          # So here we are. Thanks Windows Team.
+          #
+          # Anyway, what we *really* care about is that we exit if we_testing()
+          # errors out, and on Windows, we can do that straight from the
+          # powershell we generate there (we're not forking off awk), so the
+          # `&&` isn't as critical. It's still a bummer that we continue on
+          # if one of the commands fails, but... Well, it's Windows,
+          # whatchyagonnado?
+
+          cmds = command_list.join(' ; ')
+        else
+          cmds = command_list.join(' && ')
+        end
+        cmd = ssh
+        cc = Base64.encode64(cmds).delete("\n")
+        if TasteTester::Config.windows_target
+
+          # This is pretty horrible, but because there's no way I can find to
+          # take base64 as stdin and output text, we end up having to do use
+          # these PS functions. But they're going to pass through *both* bash
+          # *and* powershell, so in order to preserve the quotes, it gets
+          # pretty ugly.
+          #
+          # The tldr here is that in shell you can't escape quotes you're
+          # using to quote something. So if you use single quotes, there's no
+          # way to escape a single quote inside, and same with double-quotes.
+          # As such we switch between quote-styles as necessary. As long as the
+          # strings are back-to-back, shell handles this well. To make this
+          # clear, imagine you want to echo this:
+          #    '"'"
+          # Exactly like that. You would quote the first single quotes in double
+          # quotes: "'"
+          # Then the double quotes in single quotes: '"'
+          # Now repeat twice and you get: echo "'"'"'"'"'"'
+          # And that works reliably.
+          #
+          # We're doing the same thing here. What we want on the other side of
+          # the ssh is:
+          #  [Text.Encoding]::Utf8.GetString([Convert]::FromBase64String('...'))
+          #
+          # But for this to work right the command we pass to SSH has to be in
+          # single quotes too. For simplicity lets call those two functions
+          # above GetString() and Base64(). So we'll start with:
+          #    ssh host 'GetString(Base64('
+          # We've closed that string, now we add the single quote we want there,
+          # as well as the stuff inside of those double quotes, so we'll add:
+          #    '#{cc}'))
+          # but that must be in double quotes since we're using single quotes.
+          # Put that together:
+          #    ssh host 'GetString(Base64('"'#{cc}'))"
+          #             ^-----------------^^---------^
+          #              string 1           string2
+          # No we're doing with needing single quotes inside of our string, go
+          # back to using single-quotes so no variables get interpolated. We now
+          # add: ' | powershell.exe -c -; exit $LASTEXITCODE'
+          #   ssh host 'GetString(Base64('"'#{cc}'))"' | powershell.exe ...'
+          #            ^-----------------^^---------^^---------------------^
+          #
+          # More than you ever wanted to know about shell. You're welcome.
+          #
+          # But now we have to put it inside of a ruby string, :)
+
+          # just for readability, put these crazy function names inside of
+          # variables
+          fun1 = '[Text.Encoding]::Utf8.GetString'
+          fun2 = '[Convert]::FromBase64String'
+          cmd += "'#{fun1}(#{fun2}('\"'#{cc}'))\"' | "
+          #       ^----------------^ ^----------^^---
+          #        single-q           double-q    single-q
+          #        string 1           string2     string3
+          cmd += 'powershell.exe -c -; exit $LASTEXITCODE\''
+          #       ----------------------------------------^
+          #       continued string3
+        else
+          cmd += "\"echo '#{cc}' | base64 --decode"
+          if TasteTester::Config.user != 'root'
+            cmd += ' | sudo bash -x"'
+          else
+            cmd += ' | bash -x"'
+          end
+        end
+        cmd
+      end
+    end
+  end
+end

--- a/scripts/taste-untester.ps1
+++ b/scripts/taste-untester.ps1
@@ -1,0 +1,71 @@
+[CmdletBinding()]
+param(
+  [switch]$dryrun
+)
+
+# keep these as *forward* slashes
+$CONFLINK = 'C:/chef/client.rb'
+$PRODCONF = 'C:/chef/client-prod.rb'
+$CERTLINK = 'C:/chef/client.pem'
+$PRODCERT = 'C:/chef/client-prod.pem'
+$STAMPFILE = 'C:/chef/test_timestamp'
+$MYSELF = $0
+
+function log($msg) {
+  Write-EventLog -LogName "Application" -Source "taste-tester" `
+    -EventID 2 -EntryType Warning -Message $msg
+}
+
+function set_server_to_prod {
+  if (Test-Path $STAMPFILE) {
+    $content = Get-Content $STAMPFILE
+    if ($content -ne $null) {
+      kill $content -Force 2>$null
+    }
+  }
+  rm -Force $CONFLINK
+  New-Item -ItemType symboliclink -Force -Value $PRODCONF $CONFLINK
+  if (Test-Path $STAMPFILE) {
+    rm -Force $STAMPFILE
+  }
+  log "Reverted to production Chef."
+}
+
+function check_server {
+  # this is the only way to check if something is a symlink, apparently
+  if (-Not ((get-item $CONFLINK).Attributes.ToString() -match "ReparsePoint")) {
+    Write-Verbose "$CONFLINK is not a link..."
+    return
+  }
+  $current_config = (Get-Item $CONFLINK).target
+  if ($current_config -eq $PRODCONF) {
+    if (Test-Path $STAMPFILE) {
+      rm -Force $STAMPFILE
+    }
+    return
+  }
+
+  $revert = $false
+  if (-Not (Test-Path $STAMPFILE)) {
+    $revert = $true
+  } else {
+    $now = [int][double]::Parse(
+      $(Get-Date -date (Get-Date).ToUniversalTime()-uformat %s)
+    )
+    $stamp_time = Get-Date -Date `
+      (Get-Item $STAMPFILE).LastWriteTime.ToUniversalTime() -UFormat %s
+    Write-Verbose "$now vs $stamp_time"
+    if ($now -gt $stamp_time) {
+      $revert = $true
+    }
+  }
+  if ($revert) {
+    if ($dryrun) {
+      echo "DRYRUN: Would return server to prod"
+    } else {
+      set_server_to_prod
+    }
+  }
+}
+
+check_server


### PR DESCRIPTION
I can't imagine we have any desire to have TT itself run on Windows,
however, one has to manage their windows system sometime, and that means
being able to test on those systems.

This adds support for the remote system by generating the right
powershell to send over ssh.

That means there are two requirements to using this:

1. You have ssh enabled on your Windows PC
2. You set the default shell to powershell instead of cmd

Both are easily accomplished with this tiny bit of Chef:

```ruby
powershell_package 'ComputerManagementDsc' do
  action :install
end

dsc_resource 'install ssh-client' do
  resource :windowscapability
  module_name 'ComputerManagementDsc'
  property :name, 'OpenSSH.Client~~~~0.0.1.0'
  property :ensure, 'Present'
end

dsc_resource 'install ssh-server' do
  resource :windowscapability
  module_name 'ComputerManagementDsc'
  property :name, 'OpenSSH.Server~~~~0.0.1.0'
  property :ensure, 'Present'
end

dsc_resource 'start sshd' do
  resource :service
  property :name, 'sshd'
  property :startuptype, 'Automatic'
  property :state, 'Running'
  property :ensure, 'Present'
end
```

This also requires you to be on a version modern enough that symlinks
actually work - sorry, we're not re-inventing how taste-tester works
for old broken OSes. Getting Windws support here is ugly enough as it
is.

You may be wondering "but Windows has bash support now!"... and you'd be
sorta-right. You can enable WSL and Bash in modern Windows, but you end
up in a embedded linux environment. You can access the Windows
filesystem, but it's not a thing most people are going to want to do on
their windows systems. So, powershell it is.

This fully supports tunnels and non-tunnels. As far as I can tell,
everything works except "bundle mode" and "local transport", but I don't
think those are necessary here.

In order to not repeat the *crazy* trans-shell logic, I factored out
some code that was repeated (but badly, with bugs - now we *always*
specify `-o StrictHostKeyChecking=no` and friends, not just sometimes)
between ssh.rb and tunnel.rb into ssh_util.rb. I took this approach
because it was the least change, and since that's not directly related
to this PR, I wanted to minimize that. However, the long-term solution
here is to just roll tunnel.rb into ssh.rb. It already has a `tunnel`
option it ignores in the initializer.