### PR TITLE
Allow testing and untesting of hosts to be specified as extra arguments

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -56,7 +56,7 @@ Usage: taste-tester <mode> [<options>] [optional servers to test/untest]
 
 TLDR; Most common usage is:
   vi cookbooks/...              # Make your changes and commit locally
-  taste-tester test -s [host]   # Put host in test mode
+  taste-tester test [host]      # Put host in test mode
   ssh root@[host]               # Log on host
   #{the_command_shorten_to_28}  # Run chef and watch it break
   vi cookbooks/...              # Fix your cookbooks
@@ -64,7 +64,7 @@ TLDR; Most common usage is:
   ssh root@[host]               # Log on host
   #{the_command_shorten_to_28}  # Run chef and watch it succeed
   <#{verify}>
-  taste-tester untest -s [host] # Put host back in production
+  taste-tester untest [host]    # Put host back in production
                                 #   (optional - will revert itself after 1 hour)
 
 And you're done!
@@ -73,9 +73,9 @@ Note: There may be site specific testing instructions, see local documentation f
 MODES:
   test
     Sync your local repo to your virtual Chef server (same as 'upload'), and
-    point some production server(s) specified by -s (or as arguments) to your
-    virtual chef server for testing.  If you have you a plugin that uses the
-    hookpoint, it'll may amend your commit message to denote the server you tested.
+    point some production server(s) specified as arguments to your virtual
+    chef server for testing.  If you have you a plugin that uses the hookpoint,
+    it'll may amend your commit message to denote the server you tested.
     Returns:
       0 Success.
       1 Failure, e.g. host not reachable or usage error.
@@ -100,17 +100,17 @@ MODES:
     server of each role, potentially also on multiple platforms.
 
   keeptesting
-    Extend the testing time on server specified by -s by 1 hour unless
+    Extend the testing time on the servers passed as arguments by 1 hour unless
     otherwise specified by -t.
 
   untest
-    Return the server(s) specified (in -s or as arguments) to production.
+    Return the server(s) specified as arguments to production.
 
   status
     Print out the state of the world.
 
   run
-    Run #{cmd} on the machine specified by '-s' over SSH and print the output.
+    Run #{cmd} on the machine(s) specified as arguments over SSH and print the output.
     NOTE!! This is #{'NOT'.red} a sufficient test, you must log onto the remote
     machine and verify the changes you are trying to make are actually present.
 
@@ -323,16 +323,8 @@ MODES:
     end
 
     opts.on(
-      '-s', '--split', 'Split server list on commas.'
-    ) do
-      options[:split] = true
-    end
-
-    opts.on(
-      '--servers', 'DEPRECATED: Alias for --split for backward compatibility.'
-    ) do
-      options[:split] = true
-    end
+      '-s', '--servers', 'DEPRECATED: ignored for backward compatibility.'
+    )
 
     opts.on(
       '--user USER', 'Custom username for SSH, defaults to "root".' +
@@ -426,16 +418,12 @@ MODES:
 
   if ARGV
     if [:test, :untest, :runchef, :keeptesting].include?(mode.to_sym)
-      if options[:split]
-        options[:servers] = ARGV.map { |s| s.split(/,/) }.flatten
-      else
-        options[:servers] = ARGV
-      end
+      options[:servers] = ARGV.map { |s| s.split(/,/) }.flatten
+    else
+      puts "Mode #{mode} does not accept extra arguments: #{ARGV}\n\n"
+      puts parser
+      exit(1)
     end
-  else
-    puts "Mode #{mode} does not accept extra arguments: #{ARGV}\n\n"
-    puts parser
-    exit(1)
   end
 
   if File.exist?(File.expand_path(options[:config_file]))

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -48,20 +48,21 @@ module TasteTester
   end
 
   cmd = TasteTester::Config.chef_client_command
+  cmd_28 = format('%-28s', "#{cmd}")
   description = <<-ENDOFDESCRIPTION
 Welcome to taste-tester!
 
-Usage: taste-tester <mode> [<options>]
+Usage: taste-tester <mode> [<options>] [optional servers to test/untest]
 
 TLDR; Most common usage is:
   vi cookbooks/...              # Make your changes and commit locally
   taste-tester test -s [host]   # Put host in test mode
   ssh root@[host]               # Log on host
-  #{format('%-28s', "  #{cmd}")}  # Run chef and watch it break
+  #{cmd_28                   }  # Run chef and watch it break
   vi cookbooks/...              # Fix your cookbooks
   taste-tester upload           # Upload the diff
   ssh root@[host]               # Log on host
-  #{format('%-28s', "  #{cmd}")}  # Run chef and watch it succeed
+  #{cmd_28                   }  # Run chef and watch it succeed
   <#{verify}>
   taste-tester untest -s [host] # Put host back in production
                                 #   (optional - will revert itself after 1 hour)
@@ -72,14 +73,14 @@ Note: There may be site specific testing instructions, see local documentation f
 MODES:
   test
     Sync your local repo to your virtual Chef server (same as 'upload'), and
-    point some production server specified by -s to your virtual chef server for
-    testing.  If you have you a plugin that uses the hookpoint, it'll may amend
-    your commit message to denote the server you tested.
+    point some production server(s) specified by -s (or as arguments) to your
+    virtual chef server for testing.  If you have you a plugin that uses the
+    hookpoint, it'll may amend your commit message to denote the server you tested.
     Returns:
       0 Success.
       1 Failure, e.g. host not reachable or usage error.
       2 Partial success, mixture of success and failure due to hosts being taste
-        tested by other users.
+        tested by other users, or connection issues.
       3 All hosts were not taste-tested because they are being taste-tested by
         other users.
 
@@ -103,7 +104,7 @@ MODES:
     otherwise specified by -t.
 
   untest
-    Return the server specified in -s to production.
+    Return the server(s) specified (in -s or as arguments) to production.
 
   status
     Print out the state of the world.
@@ -432,6 +433,10 @@ MODES:
       exit(1)
     end
     TasteTester::Hooks.get(path)
+  end
+
+  if ARGV && [:test, :untest].include?(mode.to_sym)
+    TasteTester::Config.servers.concat ARGV
   end
 
   begin

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -323,10 +323,15 @@ MODES:
     end
 
     opts.on(
-      '-s', '--servers SERVER[,SERVER]', Array,
-      'Server to test/untest/keeptesting.'
-    ) do |s|
-      options[:servers] = s
+      '-s', '--split', 'Split server list on commas.'
+    ) do
+      options[:split] = true
+    end
+
+    opts.on(
+      '--servers', 'DEPRECATED: Alias for --split for backward compatibility.'
+    ) do
+      options[:split] = true
     end
 
     opts.on(
@@ -419,6 +424,20 @@ MODES:
 
   parser.parse!
 
+  if ARGV
+    if [:test, :untest, :runchef, :keeptesting].include?(mode.to_sym)
+      if options[:split]
+        options[:servers] = ARGV.map { |s| s.split(/,/) }.flatten
+      else
+        options[:servers] = ARGV
+      end
+    end
+  else
+    puts "Mode #{mode} does not accept extra arguments: #{ARGV}\n\n"
+    puts parser
+    exit(1)
+  end
+
   if File.exist?(File.expand_path(options[:config_file]))
     TasteTester::Config.from_file(File.expand_path(options[:config_file]))
   end
@@ -433,10 +452,6 @@ MODES:
       exit(1)
     end
     TasteTester::Hooks.get(path)
-  end
-
-  if ARGV && [:test, :untest].include?(mode.to_sym)
-    TasteTester::Config.servers.concat ARGV
   end
 
   begin

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -48,7 +48,7 @@ module TasteTester
   end
 
   cmd = TasteTester::Config.chef_client_command
-  cmd_28 = format('%-28s', "#{cmd}")
+  the_command_shorten_to_28 = format('%-28s', cmd)
   description = <<-ENDOFDESCRIPTION
 Welcome to taste-tester!
 
@@ -58,11 +58,11 @@ TLDR; Most common usage is:
   vi cookbooks/...              # Make your changes and commit locally
   taste-tester test -s [host]   # Put host in test mode
   ssh root@[host]               # Log on host
-  #{cmd_28                   }  # Run chef and watch it break
+  #{the_command_shorten_to_28}  # Run chef and watch it break
   vi cookbooks/...              # Fix your cookbooks
   taste-tester upload           # Upload the diff
   ssh root@[host]               # Log on host
-  #{cmd_28                   }  # Run chef and watch it succeed
+  #{the_command_shorten_to_28}  # Run chef and watch it succeed
   <#{verify}>
   taste-tester untest -s [host] # Put host back in production
                                 #   (optional - will revert itself after 1 hour)

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -64,6 +64,7 @@ module TasteTester
     json false
     jumps nil
     windows_target false
+    servers []
 
     # Start/End refs for calculating changes in the repo.
     #  - start_ref should be the "master" commit of the repository

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -64,7 +64,6 @@ module TasteTester
     json false
     jumps nil
     windows_target false
-    servers []
 
     # Start/End refs for calculating changes in the repo.
     #  - start_ref should be the "master" commit of the repository


### PR DESCRIPTION
'cause I was tired of having to do:
`taste-tester test -ys $( list-webservers | shuf -n 5 | paste -sd, )`
Now I can just do:
`taste-tester test -ys $( list-webservers | shuf -n 5 )`
Most useful when the list comes from a command. No longer need to `| paste -sd,`

One might think it's small, but:
1. Not everyone knows about the `| paste -sd,` trick
2. Storing the hosts in a variable allows easy processing with other tools like `parallel`