### PR TITLE
Re-add integration testing to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       run: bundle exec rspec
     - name: Run rubocop
       run: bundle exec rubocop --display-cop-names
+    - name: Run integration tests
+      run: ./test/run.sh
 # This doesn't work on PRs from forks due to GITHUB_TOKEN, which makes
 # it kinda useless for now
 # https://github.com/andrewmcodes/rubocop-linter-action/issues/68

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,6 @@ jobs:
       run: bundle exec rubocop --display-cop-names
     - name: Run integration tests
       run: ./test/run.sh
-# This doesn't work on PRs from forks due to GITHUB_TOKEN, which makes
-# it kinda useless for now
-# https://github.com/andrewmcodes/rubocop-linter-action/issues/68
-#  rubocop:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Checkout repository
-#      uses: actions/checkout@v2
-#    - name: Run Rubocop Linter
-#      uses: andrewmcodes/rubocop-linter-action@v3.2.0
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Lint Markdown
-      uses: actionshub/markdownlint@1.2.0
+      uses: actionshub/markdownlint@2.0.0
     - name: Check links
       uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ gemspec
 
 group :test, :development do
   gem 'between_meals', :git => 'https://github.com/facebook/between-meals'
+  gem 'chef-dk', '~> 3.13.0'
   gem 'chef-zero'
-  gem 'knife-solo'
   gem 'rspec-core', '~> 3.0'
   gem 'rspec-expectations', '~> 3.0'
   gem 'rspec-mocks', '~> 3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test, :development do
   gem 'between_meals', :git => 'https://github.com/facebook/between-meals'
   gem 'chef-dk', '~> 3.13.0'
   gem 'chef-zero'
+  gem 'openssl'
   gem 'rspec-core', '~> 3.0'
   gem 'rspec-expectations', '~> 3.0'
   gem 'rspec-mocks', '~> 3.0'

--- a/test/run-broken.sh
+++ b/test/run-broken.sh
@@ -15,7 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
 set -o verbose
+bundle exec chef-zero &
+ZERO=$!
+trap "kill -9 $ZERO" EXIT
+sleep 5
 rm -rf /tmp/ops
 
 function tt {

--- a/test/run-broken.sh
+++ b/test/run-broken.sh
@@ -20,14 +20,15 @@ set -o verbose
 bundle exec chef-zero &
 ZERO=$!
 trap "kill -9 $ZERO" EXIT
+SOURCE=/tmp/ops
 sleep 5
-rm -rf /tmp/ops
+rm -rf $SOURCE
 
 function tt {
-  bundle exec ./bin/taste-tester test -s localhost -y -c $1
+  bundle exec ./bin/taste-tester test -ys localhost -c $1 -vv
 }
 (
-  mkdir /tmp/ops
+  mkdir $SOURCE
 )
 tt ./test/tt-auto.rb
 if [ $? -ne 0 ]; then

--- a/test/run-git.sh
+++ b/test/run-git.sh
@@ -18,6 +18,10 @@
 
 set -e
 set -o verbose
+bundle exec chef-zero &
+ZERO=$!
+trap "kill -9 $ZERO" EXIT
+sleep 5
 rm -rf /tmp/ops
 GIT="git -c user.email='foo@bar.com' -c user.name='foobar'"
 

--- a/test/run-git.sh
+++ b/test/run-git.sh
@@ -21,16 +21,17 @@ set -o verbose
 bundle exec chef-zero &
 ZERO=$!
 trap "kill -9 $ZERO" EXIT
+SOURCE=/tmp/ops
 sleep 5
-rm -rf /tmp/ops
 GIT="git -c user.email='foo@bar.com' -c user.name='foobar'"
 
 function tt {
-  bundle exec ./bin/taste-tester test -s localhost -y -c $1 -v
+  bundle exec ./bin/taste-tester test -ys localhost -c $1 -vv
 }
 (
-  git init /tmp/ops
-  cd /tmp/ops
+  mkdir $SOURCE
+  git init $SOURCE
+  cd $SOURCE
   mkdir chef/cookbooks/cookbook1/recipes -p
   touch chef/cookbooks/cookbook1/recipes/default.rb
   echo "name 'cookbook1'" > chef/cookbooks/cookbook1/metadata.rb

--- a/test/run-hg.sh
+++ b/test/run-hg.sh
@@ -21,16 +21,17 @@ set -o verbose
 bundle exec chef-zero &
 ZERO=$!
 trap "kill -9 $ZERO" EXIT
+SOURCE=/tmp/ops
 sleep 5
-rm -rf /tmp/ops
+rm -rf $SOURCE
 HG="hg --config ui.username=foo@bar.com"
 
 function tt {
-  bundle exec ./bin/taste-tester test -s localhost -y -c $1 -v
+  bundle exec ./bin/taste-tester test -ys localhost -c $1 -vv
 }
 (
-  mkdir /tmp/ops
-  cd /tmp/ops
+  mkdir $SOURCE
+  cd $SOURCE
   hg init
   mkdir chef/cookbooks/cookbook1/recipes -p
   touch chef/cookbooks/cookbook1/recipes/default.rb

--- a/test/run-hg.sh
+++ b/test/run-hg.sh
@@ -18,6 +18,10 @@
 
 set -e
 set -o verbose
+bundle exec chef-zero &
+ZERO=$!
+trap "kill -9 $ZERO" EXIT
+sleep 5
 rm -rf /tmp/ops
 HG="hg --config ui.username=foo@bar.com"
 

--- a/test/tt-git.rb
+++ b/test/tt-git.rb
@@ -19,3 +19,4 @@ repo '/tmp/ops'
 repo_type 'git'
 timestamp_file '/tmp/test_timestamp'
 chef_config_path '/tmp'
+use_ssh_tunnels false

--- a/test/tt-hg.rb
+++ b/test/tt-hg.rb
@@ -19,3 +19,4 @@ repo '/tmp/ops'
 repo_type 'hg'
 timestamp_file '/tmp/test_timestamp'
 chef_config_path '/tmp'
+use_ssh_tunnels true


### PR DESCRIPTION
Somehow this was dropped so I'm re-adding it to the workflow and updating some of the other action steps in our CI workflow.

The upstream source for the action step to run the [rubocop linter as it's own step has been archived](https://github.com/andrewmcodes/rubocop-linter-action), so I'm cleaning that up.