### PR TITLE
Fix ARGV check, empty array is alway true

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -426,7 +426,7 @@ MODES:
 
   parser.parse!
 
-  if !ARGV.empty?
+  unless ARGV.empty?
     if [:test, :untest, :runchef, :keeptesting].include?(mode.to_sym)
       options[:servers] = ARGV.map { |s| s.split(/,/) }.flatten
     else

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -426,7 +426,7 @@ MODES:
 
   parser.parse!
 
-  if ARGV
+  if !ARGV.empty?
     if [:test, :untest, :runchef, :keeptesting].include?(mode.to_sym)
       options[:servers] = ARGV.map { |s| s.split(/,/) }.flatten
     else


### PR DESCRIPTION
#157 added this check but its always truthy because it can be an empty array and some taste-tester commands (eg `test-taster upload`) fail the following check with the error message `Mode upload does not accept extra argument: []`