### PR TITLE
Revert parallel testing functionality

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -407,16 +407,6 @@ MODES:
     ) do
       options[:skip_post_test_hook] = true
     end
-
-    opts.on(
-      '--parallel-host-requests NUMHOSTS', 'Start NUMHOSTS threads in parallel'
-    ) do |n|
-      unless n.to_i > 0
-        logger.error("Sorry, number of threads cannot be less than 1: #{n}")
-        exit(1)
-      end
-      options[:parallel_hosts] = n.to_i
-    end
   end
 
   if mode == 'help'

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -426,7 +426,7 @@ MODES:
 
   parser.parse!
 
-  unless ARGV.empty?
+  if ARGV
     if [:test, :untest, :runchef, :keeptesting].include?(mode.to_sym)
       options[:servers] = ARGV.map { |s| s.split(/,/) }.flatten
     else

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -48,23 +48,22 @@ module TasteTester
   end
 
   cmd = TasteTester::Config.chef_client_command
-  the_command_shorten_to_28 = format('%-28s', cmd)
   description = <<-ENDOFDESCRIPTION
 Welcome to taste-tester!
 
-Usage: taste-tester <mode> [<options>] [optional servers to test/untest]
+Usage: taste-tester <mode> [<options>]
 
 TLDR; Most common usage is:
   vi cookbooks/...              # Make your changes and commit locally
-  taste-tester test [host]      # Put host in test mode
+  taste-tester test -s [host]   # Put host in test mode
   ssh root@[host]               # Log on host
-  #{the_command_shorten_to_28}  # Run chef and watch it break
+  #{format('%-28s', "  #{cmd}")}  # Run chef and watch it break
   vi cookbooks/...              # Fix your cookbooks
   taste-tester upload           # Upload the diff
   ssh root@[host]               # Log on host
-  #{the_command_shorten_to_28}  # Run chef and watch it succeed
+  #{format('%-28s', "  #{cmd}")}  # Run chef and watch it succeed
   <#{verify}>
-  taste-tester untest [host]    # Put host back in production
+  taste-tester untest -s [host] # Put host back in production
                                 #   (optional - will revert itself after 1 hour)
 
 And you're done!
@@ -73,14 +72,14 @@ Note: There may be site specific testing instructions, see local documentation f
 MODES:
   test
     Sync your local repo to your virtual Chef server (same as 'upload'), and
-    point some production server(s) specified as arguments to your virtual
-    chef server for testing.  If you have you a plugin that uses the hookpoint,
-    it'll may amend your commit message to denote the server you tested.
+    point some production server specified by -s to your virtual chef server for
+    testing.  If you have you a plugin that uses the hookpoint, it'll may amend
+    your commit message to denote the server you tested.
     Returns:
       0 Success.
       1 Failure, e.g. host not reachable or usage error.
       2 Partial success, mixture of success and failure due to hosts being taste
-        tested by other users, or connection issues.
+        tested by other users.
       3 All hosts were not taste-tested because they are being taste-tested by
         other users.
 
@@ -100,17 +99,17 @@ MODES:
     server of each role, potentially also on multiple platforms.
 
   keeptesting
-    Extend the testing time on the servers passed as arguments by 1 hour unless
+    Extend the testing time on server specified by -s by 1 hour unless
     otherwise specified by -t.
 
   untest
-    Return the server(s) specified as arguments to production.
+    Return the server specified in -s to production.
 
   status
     Print out the state of the world.
 
   run
-    Run #{cmd} on the machine(s) specified as arguments over SSH and print the output.
+    Run #{cmd} on the machine specified by '-s' over SSH and print the output.
     NOTE!! This is #{'NOT'.red} a sufficient test, you must log onto the remote
     machine and verify the changes you are trying to make are actually present.
 
@@ -323,8 +322,11 @@ MODES:
     end
 
     opts.on(
-      '-s', '--servers', 'DEPRECATED: ignored for backward compatibility.'
-    )
+      '-s', '--servers SERVER[,SERVER]', Array,
+      'Server to test/untest/keeptesting.'
+    ) do |s|
+      options[:servers] = s
+    end
 
     opts.on(
       '--user USER', 'Custom username for SSH, defaults to "root".' +
@@ -415,16 +417,6 @@ MODES:
   end
 
   parser.parse!
-
-  if ARGV
-    if [:test, :untest, :runchef, :keeptesting].include?(mode.to_sym)
-      options[:servers] = ARGV.map { |s| s.split(/,/) }.flatten
-    else
-      puts "Mode #{mode} does not accept extra arguments: #{ARGV}\n\n"
-      puts parser
-      exit(1)
-    end
-  end
 
   if File.exist?(File.expand_path(options[:config_file]))
     TasteTester::Config.from_file(File.expand_path(options[:config_file]))

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -64,7 +64,8 @@ module TasteTester
     end
 
     def self.test
-      unless TasteTester::Config.servers
+      hosts = TasteTester::Config.servers
+      unless hosts
         logger.warn('You must provide a hostname')
         exit(1)
       end
@@ -81,6 +82,7 @@ module TasteTester
         end
         upload
       end
+      server = TasteTester::Server.new
       unless TasteTester::Config.linkonly
         if TasteTester::Config.no_repo
           repo = nil
@@ -97,89 +99,80 @@ module TasteTester
       end
       unless TasteTester::Config.skip_pre_test_hook ||
           TasteTester::Config.linkonly
-        TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo,
-                                    TasteTester::Config.servers)
+        TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo, hosts)
       end
-      hosts = _run_on_hosts(:test)
+      tested_hosts = []
+      hosts.each do |hostname|
+        host = TasteTester::Host.new(hostname, server)
+        begin
+          host.test
+          tested_hosts << hostname
+        rescue TasteTester::Exceptions::AlreadyTestingError => e
+          logger.error("User #{e.username} is already testing on #{hostname}")
+        end
+      end
       unless TasteTester::Config.skip_post_test_hook ||
           TasteTester::Config.linkonly
         TasteTester::Hooks.post_test(TasteTester::Config.dryrun, repo,
-                                     hosts.select { |_, r| r == :ok }.keys)
+                                     tested_hosts)
       end
-      if hosts.values.all?(:ok)
+      # Strictly: hosts and tested_hosts should be sets to eliminate variance in
+      # order or duplicates. The exact comparison works here because we're
+      # building tested_hosts from hosts directly.
+      if tested_hosts == hosts
         # No exceptions, complete success: every host listed is now configured
         # to use our chef-zero instance.
         exit(0)
       end
-      if hosts.values.none?(:ok)
-        if hosts.values.any?(:ssh_error)
-          # All the hosts we had failed, with at least one because of ssh
-          exit(1)
-        end
+      if tested_hosts.empty?
         # All requested hosts are being tested by another user. We didn't change
         # their configuration.
         exit(3)
       end
       # Otherwise, we got a mix of success and failure due to being tested by
-      # another user. We'll be pessimistic and return an error because the
+      # another user. We'll be pessemistic and return an error because the
       # intent to taste test the complete list was not successful.
+      # code.
       exit(2)
     end
 
-    def self._run_on_hosts(method)
+    def self.untest
       hosts = TasteTester::Config.servers
       unless hosts
         logger.error('You must provide a hostname')
         exit(1)
       end
       server = TasteTester::Server.new
-      hosts_result = {}
-      host_threads = []
-      queue = Queue.new
-      hosts.each { |hostname| queue << hostname }
-      [TasteTester::Config.parallel_hosts, hosts.length].min.times do
-        host_threads << Thread.new do
-          Thread.current.report_on_exception = false
-          loop do
-            begin
-              # non_block: true makes pop() throw a ThreadError when empty
-              hostname = queue.pop(true)
-              Thread.current[:hostname] = hostname
-              TasteTester::Host.new(hostname, server).send method
-            rescue ThreadError
-              break
-            end
-          end
-        end
+      hosts.each do |hostname|
+        host = TasteTester::Host.new(hostname, server)
+        host.untest
       end
-      host_threads.each do |host_thread|
-        result = :unknown_error
-        begin
-          hostname = host_thread[:hostname]
-          host_thread.join
-          result = :ok
-        rescue TasteTester::Exceptions::AlreadyTestingError => e
-          logger.error("User #{e.username} is already testing on #{hostname}")
-          result = :already_in_testing
-        rescue TasteTester::Exceptions::SshError
-          logger.error("Cannot connect to #{hostname}")
-          result = :ssh_error
-        end
-        hosts_result[hostname] = result
-      end
-      hosts_result
-    end
-
-    def self.untest
-      _run_on_hosts(:untest)
     end
 
     def self.runchef
-      _run_on_hosts(:runchef)
+      hosts = TasteTester::Config.servers
+      unless hosts
+        logger.warn('You must provide a hostname')
+        exit(1)
+      end
+      server = TasteTester::Server.new
+      hosts.each do |hostname|
+        host = TasteTester::Host.new(hostname, server)
+        host.runchef
+      end
     end
 
     def self.keeptesting
-      _run_on_hosts(:keeptesting)
+      hosts = TasteTester::Config.servers
+      unless hosts
+        logger.warn('You must provide a hostname')
+        exit(1)
+      end
+      server = TasteTester::Server.new
+      hosts.each do |hostname|
+        host = TasteTester::Host.new(hostname, server)
+        host.keeptesting
+      end
     end
 
     def self.upload

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -17,7 +17,6 @@
 require 'mixlib/config'
 require 'taste_tester/logging'
 require 'between_meals/util'
-require 'etc'
 
 module TasteTester
   # Config file parser and config object
@@ -65,7 +64,6 @@ module TasteTester
     json false
     jumps nil
     windows_target false
-    parallel_hosts Etc.nprocessors
 
     # Start/End refs for calculating changes in the repo.
     #  - start_ref should be the "master" commit of the repository


### PR DESCRIPTION
An attempt to facilitate setting up hosts in parallel was made in #157, #158, and #161 but these are breaking changes with no real backwards compatibility / transition plan to help migrate users. Until this can be safely implemented, I'm reverting these PRs.