### PR TITLE
Explicitly parse the URI when building the connection to a remote host

### DIFF
--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -365,7 +365,7 @@ module TasteTester
           FileUtils.rmtree(taste_tester_dest)
           FileUtils.mkpath(taste_tester_dest)
           FileUtils.touch(File.join(taste_tester_dest, 'chefignore'))
-          uri = URI('#{url}/file_store/tt.tgz')
+          uri = URI.parse('#{url}/file_store/tt.tgz')
           Net::HTTP.start(
             uri.host,
             uri.port,


### PR DESCRIPTION
After upgrading to ruby 2.7, the connection to a remote host started failing:
```
INFO: Downloading bundle from https://foobar9999.fake0.antartica.com:5293...
[2021-05-04T12:21:30-07:00] FATAL: Configuration error NoMethodError: undefined method `host' for "https://foobar9999.fake0.antartica.com:5293/file_store/tt.tgz":String
[2021-05-04T12:21:30-07:00] FATAL:   /etc/chef/client.rb:19:in `from_string'
[2021-05-04T12:21:30-07:00] FATAL: Aborting due to error in '/etc/chef/client.rb': undefined method `host' for "https://foobar9999.fake0.antartica.com:5293/file_store/tt.tgz":String
```
By explicitly calling `URI.parse` the data is returned in a format that the Net::HTTP library is expecting and the connection succeeds. 