### PR TITLE
Add a post_error hook to handle errors post test/untest/keeptesting/etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Custom output of calculated impact, useful if defining either of the other
 impact hooks. Must return a truthy value to prevent the default output from
 printing.
 
+* self.post_error(dryrun, exception, mode, hostname)
+
+A hook which will be called just before taste-tester throws an exception/exits.
+Passes down the `exception` object and the `mode` taste-tester was invoked with
+for further analysis and doing any additional logging, output, or cleanup.
+
 ## Plugin example
 
 This is an example `/etc/taste-tester-plugin.rb` to add a user-defined string

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -109,6 +109,11 @@ module TasteTester
           tested_hosts << hostname
         rescue TasteTester::Exceptions::AlreadyTestingError => e
           logger.error("User #{e.username} is already testing on #{hostname}")
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
         end
       end
       unless TasteTester::Config.skip_post_test_hook ||
@@ -145,7 +150,14 @@ module TasteTester
       server = TasteTester::Server.new
       hosts.each do |hostname|
         host = TasteTester::Host.new(hostname, server)
-        host.untest
+        begin
+          host.untest
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
+        end
       end
     end
 
@@ -158,7 +170,14 @@ module TasteTester
       server = TasteTester::Server.new
       hosts.each do |hostname|
         host = TasteTester::Host.new(hostname, server)
-        host.runchef
+        begin
+          host.runchef
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
+        end
       end
     end
 
@@ -171,7 +190,14 @@ module TasteTester
       server = TasteTester::Server.new
       hosts.each do |hostname|
         host = TasteTester::Host.new(hostname, server)
-        host.keeptesting
+        begin
+          host.keeptesting
+        rescue StandardError => e
+          # Call error handling hook and re-raise
+          TasteTester::Hooks.post_error(TasteTester::Config.dryrun, e,
+                                        __method__, hostname)
+          raise
+        end
       end
     end
 

--- a/lib/taste_tester/hooks.rb
+++ b/lib/taste_tester/hooks.rb
@@ -63,6 +63,11 @@ module TasteTester
     # If this method returns true, the default output will not be printed.
     def self.print_impact(_final_impact); end
 
+    # In the event of any failure, this hook will be called
+    # just before taste-tester throws an exception/exits
+    # Additional logging, output, or cleanup may be done here.
+    def self.post_error(_dryrun, _exception, _mode, _hostname); end
+
     def self.get(file)
       path = File.expand_path(file)
       logger.warn("Loading plugin at #{path}") unless TasteTester::Config.json


### PR DESCRIPTION
- testing using fb taste-tester and adding a custom hook for post_error which looked like this


```
def self.post_error(dryrun, exception, mode, hostname)
    return if dryrun

    case mode
    when :keeptesting
        logger.warn "Yay, post_error in keeptesting"
    when :test
        logger.warn "Yay, post_error in test"
    when :untest
        logger.warn "Yay, post_error in untest"
    else
        logger.error("Invalid mode: #{mode}")
        exit(1)
    end

    logger.warn "exception recieved #{exception}"
    logger.warn "host recieved #{hostname}"
end
```

- Output from runs 
```
Yay, post_error in test
exception recieved TasteTester::Exceptions::SshError
host recieved <redacted>
ERROR: Taste-testing failed. HOST NOT PUT IN TESTING MODE.
```

```
Yay, post_error in keeptesting
exception recieved TasteTester::Exceptions::SshError
host recieved <redacted>
ERROR: Taste-testing failed. HOST NOT PUT IN TESTING MODE.
```

```
Yay, post_error in untest
exception recieved TasteTester::Exceptions::SshError
host recieved <redacted>
ERROR: Taste-testing failed. HOST NOT PUT IN TESTING MODE.
```
