### PR TITLE
Add a ssh_command_generator config for running a custom ssh generator command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ The following options are also available:
   Default: false
 * impact - analyze local changes to determine which hosts/roles to test.
   Default: false
-* ssh_cmd_template - A variable to supply a custom ssh command generator which
-  will be invoked by TT to generate a vanilla command. This can be expressed in a template
-  format, with the arguments supplied using `ssh_gen_args`
+* ssh_cmd_gen_template - A variable to supply a custom ssh command
+  generator which will be invoked by TT to generate a vanilla command.
+  This can be expressed in a template format, with the arguments
+  supplied using `ssh_cmd_gen_args`
   Default: nil
 
 ## Plugin

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ The following options are also available:
   Default: false
 * impact - analyze local changes to determine which hosts/roles to test.
   Default: false
+* ssh_cmd_template - A variable to supply a custom ssh command generator which
+  will be invoked by TT to generate a vanilla command. This can be expressed in a template
+  format, with the arguments supplied using `ssh_gen_args`
+  Default: nil
 
 ## Plugin
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,16 @@ The following options are also available:
   Default: false
 * impact - analyze local changes to determine which hosts/roles to test.
   Default: false
-* ssh_cmd_gen_template - A variable to supply a custom ssh command
-  generator which will be invoked by TT to generate a vanilla command.
-  This can be expressed in a template format, with the arguments
-  supplied using `ssh_cmd_gen_args`
+* ssh_cmd_gen_template - Provide a command to run, whose stdout will be a
+  vanilla ssh command Taste Tester will invoke to access test nodes.
+  The command should be a template and will be passed the
+  following variables:
+  * `jumps` - any jumphost arguments supplied via -J option
+  * `host` - the host to SSH to
+  * `user` - the user to SSH as
+  For example:
+  `ssh_gen %{jumps} --user %{user} %{host}`
+  In addition, further arguments can be passed using `ssh_cmd_gen_args`
   Default: nil
 
 ## Plugin

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ The following options are also available:
   * `user` - the user to SSH as
   For example:
   `ssh_gen %{jumps} --user %{user} %{host}`
-  In addition, further arguments can be passed using `ssh_cmd_gen_args`
   Default: nil
 
 ## Plugin

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -54,7 +54,6 @@ module TasteTester
     ssh_command 'ssh'
     ssh_connect_timeout 5
     ssh_cmd_gen_template nil
-    ssh_cmd_gen_args {}
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -53,8 +53,8 @@ module TasteTester
     use_ssh_tunnels false
     ssh_command 'ssh'
     ssh_connect_timeout 5
-    ssh_cmd_template nil
-    ssh_gen_args {}
+    ssh_cmd_gen_template nil
+    ssh_cmd_gen_args {}
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -53,6 +53,8 @@ module TasteTester
     use_ssh_tunnels false
     ssh_command 'ssh'
     ssh_connect_timeout 5
+    ssh_cmd_template nil
+    ssh_gen_args {}
     use_ssl true
     chef_zero_logging true
     chef_config_path '/etc/chef'

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -28,6 +28,7 @@ module TasteTester
       @host = host
       @tunnel = tunnel
       @cmds = []
+      @ssh_gen_cmd = nil
     end
 
     def add(string)

--- a/lib/taste_tester/ssh.rb
+++ b/lib/taste_tester/ssh.rb
@@ -28,7 +28,7 @@ module TasteTester
       @host = host
       @tunnel = tunnel
       @cmds = []
-      @ssh_gen_cmd = nil
+      @ssh_generated_cmd = nil
     end
 
     def add(string)

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -31,14 +31,13 @@ module TasteTester
         end
       end
 
-      def ssh_gen_cmd
+      def ssh_generated_cmd
         if TasteTester::Config.ssh_cmd_template
           # we store this generated command inside a class variable
           # so that we can directly refer to this while printing
           # logs and error messages
-          @ssh_gen_cmd =
-            Mixlib::ShellOut.new(ssh_cmd_generator).run_command.stdout.chomp
-          @ssh_gen_cmd
+          @ssh_generated_cmd ||=
+	            Mixlib::ShellOut.new(ssh_cmd_generator).run_command.stdout.chomp
         end
       end
 
@@ -50,7 +49,7 @@ module TasteTester
 
       def ssh_base_cmd
         if TasteTester::Config.ssh_cmd_template
-          ssh_gen_cmd
+          ssh_generated_cmd
         else
           ssh_vanilla_cmd
         end
@@ -62,7 +61,7 @@ module TasteTester
 
       def error!
         if TasteTester::Config.ssh_cmd_template
-          ssh_cmd = "#{@ssh_gen_cmd} -v"
+          ssh_cmd = "#{@ssh_generated_cmd} -v"
         else
           ssh_cmd = "#{ssh_base_cmd} -v #{ssh_target}"
         end

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -27,7 +27,7 @@ module TasteTester
             :host => @host,
           }
           TasteTester::Config.ssh_cmd_gen_template %
-            base_gen_args.update(TasteTester::Config.ssh_cmd_gen_args)
+            base_gen_args
         end
       end
 
@@ -39,7 +39,7 @@ module TasteTester
           begin
             # run the generator command only if it's not run already
             if @ssh_generated_cmd.nil?
-              generator = Mixlib::ShellOut.new(ssh_cmd_generator)              
+              generator = Mixlib::ShellOut.new(ssh_cmd_generator)
               @ssh_generated_cmd = generator.run_command.stdout.chomp
               generator.error!
             end

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -38,10 +38,10 @@ module TasteTester
           # logs and error messages
           begin
             # run the generator command only if it's not run already
-            if @ssh_generated_cmd.nil?
-              generator = Mixlib::ShellOut.new(ssh_cmd_generator)
-              @ssh_generated_cmd = generator.run_command.stdout.chomp
+            unless @ssh_generated_cmd
+              generator = Mixlib::ShellOut.new(ssh_cmd_generator).run_command
               generator.error!
+              @ssh_generated_cmd = generator.stdout.chomp
             end
             @ssh_generated_cmd
           rescue Mixlib::ShellOut::ShellCommandFailed => e

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -37,9 +37,9 @@ module TasteTester
           # so that we can directly refer to this while printing
           # logs and error messages
           begin
-            generator = Mixlib::ShellOut.new(ssh_cmd_generator)
             # run the generator command only if it's not run already
             if @ssh_generated_cmd.nil?
+              generator = Mixlib::ShellOut.new(ssh_cmd_generator)              
               @ssh_generated_cmd = generator.run_command.stdout.chomp
               generator.error!
             end

--- a/lib/taste_tester/ssh_util.rb
+++ b/lib/taste_tester/ssh_util.rb
@@ -20,19 +20,19 @@ module TasteTester
       end
 
       def ssh_cmd_generator
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           base_gen_args = {
             :user => TasteTester::Config.user,
             :jumps => jumps,
             :host => @host,
           }
-          TasteTester::Config.ssh_cmd_template %
-            base_gen_args.update(TasteTester::Config.ssh_gen_args)
+          TasteTester::Config.ssh_cmd_gen_template %
+            base_gen_args.update(TasteTester::Config.ssh_cmd_gen_args)
         end
       end
 
       def ssh_generated_cmd
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           # we store this generated command inside a class variable
           # so that we can directly refer to this while printing
           # logs and error messages
@@ -62,7 +62,7 @@ module TasteTester
       end
 
       def ssh_base_cmd
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           ssh_generated_cmd
         else
           ssh_vanilla_cmd
@@ -79,7 +79,7 @@ module TasteTester
 
       ERRORMESSAGE
 
-        if TasteTester::Config.ssh_cmd_template
+        if TasteTester::Config.ssh_cmd_gen_template
           error += <<~ERRORMESSAGE
 
   The above command was generated, and it may be useful to run the generator directly instead:

--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -29,11 +29,14 @@ module TasteTester
 
     def initialize(host, server)
       @host = host
+      @port = TasteTester::Config.tunnel_port
       @server = server
+      @extra_options = '-o ServerAliveInterval=10 ' +
+        '-o ServerAliveCountMax=6 ' +
+        "-f -R #{@port}:localhost:#{@server.port} "
     end
 
     def run
-      @port = TasteTester::Config.tunnel_port
       logger.info("Setting up tunnel on port #{@port}")
       exec!(cmd, logger)
     rescue StandardError => e
@@ -54,9 +57,7 @@ module TasteTester
       # In most cases the first request from chef was "breaking" the tunnel,
       # in a way that port was still open, but subsequent requests were hanging.
       # This is reproducible and should be looked into.
-      cmd = "#{ssh_base_cmd} -o ServerAliveInterval=10 " +
-        "-o ServerAliveCountMax=6 -f -R #{@port}:localhost:#{@server.port} "
-      build_ssh_cmd(cmd, [cmds])
+      build_ssh_cmd(ssh_base_cmd, [cmds])
     end
 
     def self.kill(name)

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -149,8 +149,8 @@ describe TasteTester::SSH do
       TasteTester::Config.user 'rossi'
       TasteTester::Config.ssh_cmd_template 'mock_generator_cmd ' +
         '%{arg1} %{arg2} %{jumps} %{host} --user %{user} --get-command'
-      ssh_gen_args_dict = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
-      TasteTester::Config.ssh_gen_args ssh_gen_args_dict
+      ssh_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
+      TasteTester::Config.ssh_gen_args ssh_gen_args_hash
       allow(mock_so).to receive(:run_command).and_return(mock_so)
       allow(mock_so).to receive(:error?).and_return(false)
       allow(mock_so).to receive(:stderr).and_return('')

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -148,9 +148,7 @@ describe TasteTester::SSH do
       TasteTester::Config.jumps 'mock_jump_user@mock_jump_host'
       TasteTester::Config.user 'rossi'
       TasteTester::Config.ssh_cmd_gen_template 'mock_generator_cmd ' +
-        '%{arg1} %{arg2} %{jumps} %{host} --user %{user} --get-command'
-      ssh_cmd_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
-      TasteTester::Config.ssh_cmd_gen_args ssh_cmd_gen_args_hash
+        'mock_arg1 mock_arg2 %{jumps} %{host} --user %{user} --get-command'
       allow(mock_so).to receive(:run_command).and_return(mock_so)
       allow(mock_so).to receive(:error?).and_return(false)
       allow(mock_so).to receive(:error!).and_return(mock_generated_cmd)

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -147,10 +147,10 @@ describe TasteTester::SSH do
       TasteTester::Config.ssh_connect_timeout 10
       TasteTester::Config.jumps 'mock_jump_user@mock_jump_host'
       TasteTester::Config.user 'rossi'
-      TasteTester::Config.ssh_cmd_template 'mock_generator_cmd ' +
+      TasteTester::Config.ssh_cmd_gen_template 'mock_generator_cmd ' +
         '%{arg1} %{arg2} %{jumps} %{host} --user %{user} --get-command'
-      ssh_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
-      TasteTester::Config.ssh_gen_args ssh_gen_args_hash
+      ssh_cmd_gen_args_hash = { :arg1 => 'mock_arg1', :arg2 => 'mock_arg2' }
+      TasteTester::Config.ssh_cmd_gen_args ssh_cmd_gen_args_hash
       allow(mock_so).to receive(:run_command).and_return(mock_so)
       allow(mock_so).to receive(:error?).and_return(false)
       allow(mock_so).to receive(:error!).and_return(mock_generated_cmd)

--- a/spec/tunnel_spec.rb
+++ b/spec/tunnel_spec.rb
@@ -63,7 +63,7 @@ describe TasteTester::Tunnel do
         '-o ServerAliveInterval=10 ' +
         '-o ServerAliveCountMax=6 ' +
         '-f ' +
-        '-R :localhost:1234  ' +
+        '-R 4001:localhost:1234 ' +
         'root@mock_host',
       )
       expect(tt_tunnel.cmd).to include(
@@ -95,7 +95,7 @@ describe TasteTester::Tunnel do
         '-o ServerAliveInterval=10 ' +
         '-o ServerAliveCountMax=6 ' +
         '-f ' +
-        '-R :localhost:1234  ' +
+        '-R 4001:localhost:1234 ' +
         'rossi@mock_host',
       )
       expect(tt_tunnel.cmd).to include(
@@ -127,7 +127,7 @@ describe TasteTester::Tunnel do
         '-o ServerAliveInterval=10 ' +
         '-o ServerAliveCountMax=6 ' +
         '-f ' +
-        '-R :localhost:1234  ' +
+        '-R 4001:localhost:1234 ' +
         'rossi@mock_host',
       )
       expect(tt_tunnel.cmd).to include(


### PR DESCRIPTION
Tested with and without `ssh_command_generator` in the config

* Without
```
The host might be broken or your SSH access is not working properly
Try doing

    TERM=screen.xterm-256color SSH_AUTH_SOCK=/tmp/cloud-ssh-nish-agent /bin/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 22  -T -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=60 -v centos@<redacted_host>

to see if ssh connection is good.

If ssh works, add '-v' key to taste-tester to see the list of commands it's
trying to execute, and try to run them manually on destination host
```

* With direct host
```
SSH returned error while connecting to centos@<redacted_host>
The host might be broken or your SSH access is not working properly
Try running the following command to see if ssh is good:

    TERM=screen.xterm-256color SSH_AUTH_SOCK=/tmp/cloud-ssh-nish-agent /bin/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 22 -o ServerAliveInterval=60 -o ServerAliveCountMax=5 -o 'ProxyCommand=<redacted> %h %p' centos@<redacted_host> -v


The above command was generated, and it may be useful to run the generator directly instead:

    mock_command_generator --user centos --get-command

If ssh works, add '-v' key to taste-tester to see the list of commands it's
trying to execute, and try to run them manually on destination host
```

* With jumphost
```
SSH returned error while connecting to centos@bad_host
The host might be broken or your SSH access is not working properly
Try running the following command to see if ssh is good:

    TERM=screen.xterm-256color SSH_AUTH_SOCK=/tmp/cloud-ssh-nish-agent /bin/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 22 -o ServerAliveInterval=60 -o ServerAliveCountMax=5 -o 'ProxyCommand=/bin/ssh -W %h:%p -o "ProxyCommand=<redacted> %%h %%p" centos@<jump_host>' centos@bad_host -v


The above command was generated, and it may be useful to run the generator directly instead:

    mock_command_generator -J <jump_host> bad_host --user centos --get-command

If ssh works, add '-v' key to taste-tester to see the list of commands it's
trying to execute, and try to run them manually on destination host
```

* Test with --use-ssh-tunnels and generator code
```
$ taste-tester <redacted_options > -J <redacted_jumphost> -s <redacted_host> --use-ssh-tunnels --yes
Loading plugin at /etc/taste-tester/hooks/cloud-hooks.rb
Using /home/nish/opsfiles
Uploading cookbooks: [fb_chef_client]
Taste-testing on <redacted_host>
Waiting for prod chef runs to complete on <redacted_host>
.
.
The host is now in testing mode. You will need to run chefctl (or soloctl
as appropriate) manually while the server is in testing mode.
.
.
```
* Test with --no-use-ssh-tunnels and generator code
```
$ taste-tester <redacted_options> -J <redacted_jumphost> -s <redacted_host> --no-use-ssh-tunnels --yes
Loading plugin at /etc/taste-tester/hooks/cloud-hooks.rb
Using /home/nish/opsfiles
Uploading cookbooks: [fb_chef_client]
Taste-testing on <redacted_host>
Waiting for prod chef runs to complete on <redacted_host>
.
.
The host is now in testing mode. You will need to run chefctl (or soloctl
as appropriate) manually while the server is in testing mode.
.
.
```

* Sanity test with tunnels without generator code
```
$ taste-tester --solo <example> test --use-ssh-tunnels --user centos -s <redacted_host> 
Taste-tester type: fb-chef-solo[<example>]
Loading plugin at /etc/taste-tester/hooks/<example>.rb
Set ["<example>"] to test mode? [y/N] y
Using /home/nish/opsfiles
Nothing to upload!
Taste-testing on <example>
Waiting for prod chef runs to complete on <example>
.
The host is now in testing mode. You will need to run chefctl (or soloctl
as appropriate) manually while the server is in testing mode. See..
```

* Test failure with bullshit args in the config
```
$ taste-tester <redacted_options> -J <redacted_jumphost> -s <redacted_host> --skip-repo-checks --no-use-ssh-tunnels --yes
Loading plugin at /etc/taste-tester/hooks/cloud-hooks.rb
Using /home/nish/opsfiles
Uploading cookbooks: [fb_chef_client]
Taste-testing on <redacted_host>
The generator command: <redacted_gen_cmd> --user centos --get-command-nish failed during execution
Expected process to exit with [0], but received '1'
---- Begin output of <redacted_gen_cmd> --user centos --get-command-nish ----
STDOUT:
STDERR: /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/mixlib-shellout-2.4.4/lib/mixlib/shellout/unix.rb:340: warning: Insecure world writable dir /var/www/scripts in PATH, mode 040777
Usage: <redacted_gen_cmd>
Try '<redacted_gen_cmd> -h' for help.

Error: no such option: --get-command-nish
---- End output of <redacted_gen_cmd>l --user centos --get-command-nish ----
Ran <redacted_gen_cmd> --user centos --get-command-nish returned 1
```
