### PR TITLE
Update references to default branch for name change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 jobs:
   ruby:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ RubyGems.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 1. If you've added code that should be tested, add tests.
 1. If you've changed APIs, update the documentation.
 1. Ensure the test suite passes.

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -275,7 +275,7 @@ module TasteTester
       # We want to compare changes in the current directory (working set) with
       # the "most recent" commit in the VCS. For SVN, this will be the latest
       # commit on the checked out repository (i.e. 'trunk'). Git/Hg may have
-      # different tags or labels assigned to the master branch, (i.e. 'master',
+      # different tags or labels assigned to the default branch, (i.e. 'main',
       # 'stable', etc.) and should be configured if different than the default.
       start_ref = case repo
                   when BetweenMeals::Repo::Svn


### PR DESCRIPTION
The default branch of this repo is now 'main', so I'm updating the workflows and documentation to reflect that. I'm also updating a random comment in the code while I'm here.