### PR TITLE
Update client.rb

### DIFF
--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -199,7 +199,7 @@ module TasteTester
             )
             populate(
               stream, writer, TasteTester::Config.relative_databag_dir,
-              'databag'
+              'data_bags'
             )
           end
           stream.close


### PR DESCRIPTION
See #179. This should be `data_bags` per https://github.com/chef/chef/blob/61a11902ab814aad3625eb4da7e3345d63ee7c09/knife/lib/chef/knife/data_bag_from_file.rb#L64

To repro:
1. Set up taste-tester to use the `bundle` option
2. Set up a client with a runlist containing databags to work with the local bundle
3. Observe that you get a 404. 
4. Set `data_bag_path "#{taste_tester_dest}/databag"` in the client config and observe it now works

To test this change:
1. Create this change locally: `sed -i "s#'databag'#'data_bags'#" /path/to/taste_tester/lib/taste_tester/client.rb`
2. Upload a new bundle. Remove the `data_bag_path` override
3. Observe Chef in local mode now works