### PR TITLE
Add parallel host operations with opt-in concurrent upload and structured results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: ["2.7", "3.0", "3.1"]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ group :test, :development do
   gem 'rspec-core', '~> 3.11'
   gem 'rspec-expectations', '~> 3.11'
   gem 'rspec-mocks', '~> 3.11'
-  gem 'rubocop', '= 1.3.1'
+  gem 'rubocop', '= 1.25.1'
 end

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -409,6 +409,16 @@ MODES:
     ) do
       options[:skip_post_test_hook] = true
     end
+
+    opts.on(
+      '--parallel-host-requests NUMHOSTS', 'Start NUMHOSTS threads in parallel'
+    ) do |n|
+      unless n.to_i > 0
+        logger.error("Sorry, number of threads cannot be less than 1: #{n}")
+        exit(1)
+      end
+      options[:parallel_hosts] = n.to_i
+    end
   end
 
   if mode == 'help'

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -411,6 +411,15 @@ MODES:
     end
 
     opts.on(
+      '-b', '--bundle BUNDLE_SETTING', ['true', 'false', 'compatible'], 'Bundle mode setting'
+    ) do |bundle_setting|
+      if ['true', 'false'].include?(bundle_setting)
+        bundle_setting = bundle_setting == 'true'
+      end
+      options[:bundle] = bundle_setting
+    end
+
+    opts.on(
       '--parallel-host-requests NUMHOSTS', 'Start NUMHOSTS threads in parallel'
     ) do |n|
       unless n.to_i > 0

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -70,7 +70,8 @@ module TasteTester
       server = TasteTester::Server.new
       hosts.each do |hostname|
         # Poor man thread pool manager: keeping it simple
-        nb_threads_over_max = host_threads.length - TasteTester::Config.parallel_hosts
+        nb_threads_over_max = host_threads.length -
+          TasteTester::Config.parallel_hosts
         if nb_threads_over_max >= 0
           host_threads[nb_threads_over_max].join
         end
@@ -98,11 +99,10 @@ module TasteTester
         end
       end
       if mode == :test
-        puts "Repo is: #{repo} -- parallel"
         unless TasteTester::Config.skip_post_test_hook ||
             TasteTester::Config.linkonly
           TasteTester::Hooks.post_test(TasteTester::Config.dryrun, repo,
-                                      tested_hosts)
+                                       tested_hosts)
         end
       end
       if tested_hosts.to_set == hosts.to_set
@@ -163,7 +163,6 @@ module TasteTester
           TasteTester::Config.linkonly
         TasteTester::Hooks.pre_test(TasteTester::Config.dryrun, repo, hosts)
       end
-      puts "Repo is: #{repo} -- before parallel"
       self.run_parallel(:test, hosts, repo)
     end
 

--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -151,7 +151,6 @@ module TasteTester
 
     def self.test
       do_upload = false
-      logger.warn('Using babar threaded taste-tester')
       hosts = TasteTester::Config.servers
       unless hosts
         logger.warn('You must provide a hostname')

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -17,6 +17,7 @@
 require 'mixlib/config'
 require 'taste_tester/logging'
 require 'between_meals/util'
+require 'etc'
 
 module TasteTester
   # Config file parser and config object
@@ -67,6 +68,7 @@ module TasteTester
     json false
     jumps nil
     windows_target false
+    parallel_hosts Etc.nprocessors
 
     # Start/End refs for calculating changes in the repo.
     #  - start_ref should be the "master" commit of the repository

--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -33,6 +33,7 @@ module TasteTester
       @first = true
       super(fd)
     end
+
     def <<(obj)
       if @first
         @first = false

--- a/taste_tester.gemspec
+++ b/taste_tester.gemspec
@@ -14,7 +14,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'taste_tester'
-  s.version = '0.0.19'
+  s.version = '0.0.21'
   s.summary = 'Taste Tester'
   s.description = 'Utility for testing Chef changes using chef-zero'
   s.license = 'Apache-2.0'


### PR DESCRIPTION
## Summary

Add bounded parallel host operations for `test`, `untest`, `run`, and `keeptesting`, rebased onto current upstream `main`. Host concurrency defaults to the local CPU count and is configurable through `--parallel-host-requests` or `parallel_hosts`. Chef output is prefixed with the hostname.

Upload completes before host configuration by default. Users can explicitly overlap these phases with `--unsafe-parallel-upload` or `unsafe_parallel_upload true` in their config. In this mode:

- The local server is initialized before hosts are configured.
- Default-visible warnings explain that host progress does not mean Chef can run safely, including when hosts finish while upload is still pending.
- The final upload-complete notification lists the successfully configured hosts only after upload succeeds.
- Upload failure suppresses readiness, exits with code 20, and tells users to successfully retry upload or untest the affected hosts. It does not automatically roll back host configuration.

## Results and review fixes

- Distinct exit codes cover all-failed versus partially-failed operations and SSH, already-testing, other, or mixed failure categories: 10–13 for total failures, 14–17 for partial failures; 0 remains success and 1 covers usage/unexpected errors.
- Optional `--results-json PATH` / `results_json '/path/results.json'` writes an atomic JSON report with per-host results, upload status, process exit code, and `ready_to_run_chef`. Upload failure never marks a host ready, even if its configuration succeeded. Existing `impact --json` behavior is unchanged.
- Fix thread-limit joins, avoid duplicate error-hook calls, preserve the originating command in error hooks, and distinguish remote Chef exit statuses from internal failure categories.
- Address review style comments, explicitly subclass `::IO`, replace the stdout descriptor literal with `STDOUT.fileno`, and bump the version to `0.1.0`.
- Document configuration, exit-code changes, JSON schema, and recovery behavior in README.

## Validation

- 56 RSpec examples pass, including upstream reverse-tunnel coverage and regressions for concurrency limits, upload ordering/failure, all exit-code categories, and JSON reporting.
- RuboCop: no offenses. README Markdown lint passes.
- No-op CLI smoke tests verify JSON output via the CLI flag and config setting without contacting hosts.
- Local tests used the available Ruby 3.4.7 with a temporary validation Gemfile adding the `syslog` gem required by older Chef on Ruby 3.4. Ruby 2.6 syntax checks pass; the CI Ruby matrix has not been run locally.
- No live-host or internal-wrapper testing was performed.

Signed-off-by: Olivier Raginel <babar@fb.com>
