### PR TITLE
Fix track_symlinks reference in taste-tester impact

### DIFF
--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -300,7 +300,7 @@ module TasteTester
           :databag_dir =>
             TasteTester::Config.relative_databag_dir,
         },
-        @track_symlinks,
+        TasteTester::Config.track_symlinks,
       )
 
       return changeset


### PR DESCRIPTION
[@track_symlinks is set for TasteTester::Client](https://github.com/dtheyer/taste-tester/blob/main/lib/taste_tester/client.rb#L67), but not for TasteTester::Commands so this reference is always interpreted as false. The impact of this is that taste-tester impact is unable to detect changed files that are symlinked into the TasteTester::Config.relative_cookbook_dirs.

Since we are already referencing other config options within this function we can just read TasteTester::Config.track_symlinks directly.

Tested locally and verified that when track_symlinks is specified as true in the config, taste-tester impact adds the files to the returned changeset