### PR TITLE
[rubocop] Update RuboCop version to 1.3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,10 @@
 inherit_from:
-  - https://raw.githubusercontent.com/facebook/chef-cookbooks/main/.rubocop_55.yml
+  - https://raw.githubusercontent.com/facebook/chef-cookbooks/main/.rubocop.yml
+
+# TODO - ratchet lint into place
+Style/GlobalStdStream:
+  Enabled: false
+
+# TODO - ratchet lint into place
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ group :test, :development do
   gem 'rspec-core', '~> 3.0'
   gem 'rspec-expectations', '~> 3.0'
   gem 'rspec-mocks', '~> 3.0'
-  gem 'rubocop', '~> 0.55.0'
+  gem 'rubocop', '= 1.3.1'
 end


### PR DESCRIPTION
Looking to get the RuboCop versions in sync as I start working on the OSS CI stuff. Leaving the rubocop output cleanup to a different PR