### PR TITLE
Add problem matcher for rubocop.

### DIFF
--- a/.github/rubocop_matcher.json
+++ b/.github/rubocop_matcher.json
@@ -1,0 +1,32 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "rubocop-error",
+            "severity": "error",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):(\\d+): C: ((.+): .+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4,
+                    "code": 5
+                }
+            ]
+        },
+        {
+            "owner": "rubocop-warning",
+            "severity": "warning",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):(\\d+): W: ((.+): .+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4,
+                    "code": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,10 @@ jobs:
       run: bundle install
     - name: Run rspec
       run: bundle exec rspec
+    - name: Enable rubocop matcher
+      run: echo "::add-matcher::.github/rubocop_matcher.json"
     - name: Run rubocop
       run: bundle exec rubocop --display-cop-names
-# This doesn't work on PRs from forks due to GITHUB_TOKEN, which makes
-# it kinda useless for now
-# https://github.com/andrewmcodes/rubocop-linter-action/issues/68
-#  rubocop:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Checkout repository
-#      uses: actions/checkout@v3
-#    - name: Run Rubocop Linter
-#      uses: andrewmcodes/rubocop-linter-action@v3.2.0
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   markdown:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Regex courtesy of [r7kamura](https://github.com/r7kamura/rubocop-problem-matchers-action/blob/main/.github/matchers/rubocop.json). You can test this by modifying my branch with something that will cause a rubocop rule failure.