### PR TITLE
Fix -m flag for IPv6 addresses

### DIFF
--- a/lib/taste_tester/host.rb
+++ b/lib/taste_tester/host.rb
@@ -367,7 +367,7 @@ module TasteTester
           FileUtils.touch(File.join(taste_tester_dest, 'chefignore'))
           uri = URI.parse('#{url}/file_store/tt.tgz')
           Net::HTTP.start(
-            uri.host,
+            uri.hostname,
             uri.port,
             :use_ssl => #{TasteTester::Config.use_ssl},
             # we expect self signed certificates


### PR DESCRIPTION
Summary:

_--my-hostname_ (or _-m_) flag is used to pass hostnames test clients are supposed to talk to. Those are the addresses the tested chef client will be pulling changed cookbooks from. Unfortunately, it doesn't work if you try to pass IPv6 address - you'll get an error. In particular, `taste-tester test <test_host> -m [IPv6]` won't work.

The underlying problem is that open opening http(s) connection to the provided hostname we use `uri.host` - this version won't remove [] for IPv6 addresses. There is a replacement `uri.hostname` which will remove square brackets and make the it work.

Test Plan:

Tested on a host without a change - the error is

```
Failed to open TCP connection to [IPv6]:port (getaddrinfo: Name or service not known)
```

When changed client.rb from `uri.host` to `uri.hostname` everything work.