### PR TITLE
Assume lazy-loading of BetweenMeals repository classes

### DIFF
--- a/lib/taste_tester/hooks.rb
+++ b/lib/taste_tester/hooks.rb
@@ -16,8 +16,7 @@
 
 require 'taste_tester/logging'
 require 'between_meals/util'
-require 'between_meals/repo/hg'
-require 'between_meals/repo/git'
+require 'between_meals/repo'
 
 module TasteTester
   # Hooks placeholders


### PR DESCRIPTION
This change is in anticipation of https://github.com/facebook/between-meals/pull/136, where we only load a class if it's actually in use (ie this allows operation without the rugged gem)