### PR TITLE
Fix load order of _find_changeset for `impact`

### DIFF
--- a/lib/taste_tester/commands.rb
+++ b/lib/taste_tester/commands.rb
@@ -278,12 +278,12 @@ module TasteTester
       # different tags or labels assigned to the default branch, (i.e. 'main',
       # 'stable', etc.) and should be configured if different than the default.
       start_ref = case repo
+                  when BetweenMeals::Repo::Hg
+                    TasteTester::Config.vcs_start_ref_hg
                   when BetweenMeals::Repo::Svn
                     repo.latest_revision
                   when BetweenMeals::Repo::Git
                     TasteTester::Config.vcs_start_ref_git
-                  when BetweenMeals::Repo::Hg
-                    TasteTester::Config.vcs_start_ref_hg
                   end
       end_ref = TasteTester::Config.vcs_end_ref
 


### PR DESCRIPTION
The loading order of the repo constants changed in BetweenMeals for https://github.com/facebook/between-meals/issues/130 in https://github.com/facebook/between-meals/commit/e02a7ca003f44a8ad801517b5c8074f0f4a33027. This causes issues when running the `impact` command, where SVN may not yet be loaded. This fix matches the new order, though longer term I'd like to have a getter method for the `Repo` class so that we don't need to put specific Repo constants in Taste-Tester, since that's brittle to VCS systems getting added/removed.