### PR TITLE
Speed up bundle uploads

### DIFF
--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -22,8 +22,14 @@ require 'between_meals/knife'
 require 'between_meals/changeset'
 require 'chef/log'
 require 'chef/cookbook/chefignore'
+require 'parallel'
+require 'etc'
 
 module TasteTester
+
+  BASE_PATH_INDEX = 0
+  RELATIVE_PATH_INDEX = 1
+  DESTINATION_PATH_INDEX = 2
   # Client side upload functionality
   # Ties together Repo/Changeset diff logic
   # and Server/Knife uploads
@@ -129,22 +135,17 @@ module TasteTester
 
     private
 
-    def populate(stream, writer, path, destination)
+    def gen_file_list(path, destination)
+      targets = []
       full_path = File.join(File.join(TasteTester::Config.repo, path))
       return unless File.directory?(full_path)
-      chefignores = Chef::Cookbook::Chefignore.new(full_path)
-      # everything is relative to the repo dir. chdir makes handling all the
-      # paths within this simpler
       Dir.chdir(full_path) do
         look_at = ['']
         while (prefix = look_at.pop)
           Dir.glob(File.join("#{prefix}**", '*'), File::FNM_DOTMATCH) do |p|
-            minus_first = p.split(
-              File::SEPARATOR,
-            )[1..-1].join(File::SEPARATOR)
-            next if chefignores.ignored?(p) ||
-              chefignores.ignored?(minus_first)
-            name = File.join(destination, p)
+            sep_index = p.index(File::SEPARATOR)
+            minus_first = sep_index.nil? ? '' : p.slice(sep_index+1..)
+
             if File.directory?(p)
               # we don't store directories in the tar, but we do want to follow
               # top level symlinked directories as they are used to share
@@ -152,7 +153,30 @@ module TasteTester
               if minus_first == '' && File.symlink?(p)
                 look_at.push("#{p}#{File::SEPARATOR}")
               end
-            elsif File.symlink?(p)
+            else
+              targets << [full_path, p, destination]
+            end
+          end
+        end
+      end
+      targets
+    end
+
+    def generate_intermediate_tar(bucket, i)
+      stream = Tempfile.create([i.to_s, '.tar'], @server.bundle_dir)
+        Minitar::Writer.open(stream) do |writer|
+          bucket.each do |file_entry|
+            file_path = File.join(file_entry[BASE_PATH_INDEX], file_entry[RELATIVE_PATH_INDEX])
+            name = File.join(file_entry[DESTINATION_PATH_INDEX], file_entry[RELATIVE_PATH_INDEX])
+
+            sep_index = file_entry[RELATIVE_PATH_INDEX].index(File::SEPARATOR)
+            minus_first = sep_index.nil? ? '' : file_entry[RELATIVE_PATH_INDEX].slice(sep_index+1..)
+
+            chefignores = Chef::Cookbook::Chefignore.new(file_path)
+            next if chefignores.ignored?(file_entry[RELATIVE_PATH_INDEX]) ||
+              chefignores.ignored?(minus_first)
+
+            if File.symlink?(file_path)
               # tar handling of filenames > 100 characters gets complex. We'd
               # use split_name from Minitar, but it's a private method. It's
               # reasonable to assume that all symlink names in the bundle are
@@ -167,12 +191,12 @@ module TasteTester
                 :mode => 0644,
                 :typeflag => '2',
                 :size => 0,
-                :linkname => File.readlink(p),
+                :linkname => File.readlink(file_path),
                 :prefix => '',
               }
               stream.write(Minitar::PosixHeader.new(symlink))
             else
-              File.open(p, 'rb') do |r|
+              File.open(file_path, 'rb') do |r|
                 writer.add_file_simple(
                   name, :mode => 0644, :size => File.size(r)
                 ) do |d, _opts|
@@ -181,27 +205,25 @@ module TasteTester
               end
             end
           end
+
         end
-      end
+        stream.close
+        stream.path
     end
 
-    def bundle_upload
+    def assemble_bundle(files)
       dest = File.join(@server.bundle_dir, 'tt.tgz')
       begin
         Tempfile.create(['tt', '.tgz'], @server.bundle_dir) do |tempfile|
-          stream = Zlib::GzipWriter.new(tempfile)
-          Minitar::Writer.open(stream) do |writer|
-            TasteTester::Config.relative_cookbook_dirs.each do |cb_dir|
-              populate(stream, writer, cb_dir, 'cookbooks')
-            end
-            populate(
-              stream, writer, TasteTester::Config.relative_role_dir, 'roles'
-            )
-            populate(
-              stream, writer, TasteTester::Config.relative_databag_dir,
-              'data_bags'
-            )
+          stream = Zlib::GzipWriter.new(tempfile, TasteTester::Config.bundle_compression_level)
+          files.sort.each do |chunk_path|
+            chunk = File.open(chunk_path, 'rb')
+            # don't copy end blocks
+            IO.copy_stream(chunk, stream, (chunk.size - 1024))
+            chunk.close
+            File.unlink(chunk.path)
           end
+          stream.write("\0" * 1024)
           stream.close
           File.rename(tempfile.path, dest)
         end
@@ -211,6 +233,30 @@ module TasteTester
         # but this is fine and expected.
         nil
       end
+    end
+
+    def bundle_upload
+      src_dirs = {
+        TasteTester::Config.relative_role_dir => 'roles',
+        TasteTester::Config.relative_databag_dir => 'data_bags',
+      }
+      TasteTester::Config.relative_cookbook_dirs.each do |cb_dir|
+        src_dirs[cb_dir] = 'cookbooks'
+      end
+
+      file_list = []
+      src_dirs.each { |path, dest|  file_list += gen_file_list(path, dest) }
+
+      processes = TasteTester::Config.bundle_generation_processes || Etc.nprocessors
+      if processes > 1
+        buckets = file_list.each_slice((file_list.length/processes.to_f).round.to_i).to_a
+        chunks = Parallel.map((0...buckets.length), in_processes: buckets.length) do |i|
+          generate_intermediate_tar(buckets[i], i)
+        end
+      else
+        chunks = [generate_intermediate_tar(file_list, 0)]
+      end
+      assemble_bundle(chunks)
     end
 
     def full

--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -144,7 +144,7 @@ module TasteTester
         while (prefix = look_at.pop)
           Dir.glob(File.join("#{prefix}**", '*'), File::FNM_DOTMATCH) do |p|
             sep_index = p.index(File::SEPARATOR)
-            minus_first = sep_index.nil? ? '' : p.slice(sep_index+1..)
+            minus_first = sep_index.nil? ? '' : p[sep_index+1..-1]
 
             if File.directory?(p)
               # we don't store directories in the tar, but we do want to follow
@@ -162,15 +162,15 @@ module TasteTester
       targets
     end
 
-    def generate_intermediate_tar(bucket, i)
-      stream = Tempfile.create([i.to_s, '.tar'], @server.bundle_dir)
+    def generate_intermediate_tar(bucket, i, prefix)
+      stream = Tempfile.create([prefix, i.to_s, '.tar'], @server.bundle_dir)
         Minitar::Writer.open(stream) do |writer|
           bucket.each do |file_entry|
             file_path = File.join(file_entry[BASE_PATH_INDEX], file_entry[RELATIVE_PATH_INDEX])
             name = File.join(file_entry[DESTINATION_PATH_INDEX], file_entry[RELATIVE_PATH_INDEX])
 
             sep_index = file_entry[RELATIVE_PATH_INDEX].index(File::SEPARATOR)
-            minus_first = sep_index.nil? ? '' : file_entry[RELATIVE_PATH_INDEX].slice(sep_index+1..)
+            minus_first = sep_index.nil? ? '' : file_entry[RELATIVE_PATH_INDEX][sep_index+1..]
 
             chefignores = Chef::Cookbook::Chefignore.new(file_path)
             next if chefignores.ignored?(file_entry[RELATIVE_PATH_INDEX]) ||
@@ -221,7 +221,6 @@ module TasteTester
             # don't copy end blocks
             IO.copy_stream(chunk, stream, (chunk.size - 1024))
             chunk.close
-            File.unlink(chunk.path)
           end
           stream.write("\0" * 1024)
           stream.close
@@ -236,6 +235,7 @@ module TasteTester
     end
 
     def bundle_upload
+      puts "Running bundle upload"
       src_dirs = {
         TasteTester::Config.relative_role_dir => 'roles',
         TasteTester::Config.relative_databag_dir => 'data_bags',
@@ -247,16 +247,22 @@ module TasteTester
       file_list = []
       src_dirs.each { |path, dest|  file_list += gen_file_list(path, dest) }
 
-      processes = TasteTester::Config.bundle_generation_processes || Etc.nprocessors
-      if processes > 1
-        buckets = file_list.each_slice((file_list.length/processes.to_f).round.to_i).to_a
-        chunks = Parallel.map((0...buckets.length), in_processes: buckets.length) do |i|
-          generate_intermediate_tar(buckets[i], i)
+      chunks = []
+      prefix = Time.now.to_i.to_s
+      begin
+        processes = TasteTester::Config.bundle_generation_processes || Etc.nprocessors
+        if processes > 1
+          buckets = file_list.each_slice((file_list.length/processes.to_f).round.to_i).to_a
+          chunks = Parallel.map((0...buckets.length), in_processes: buckets.length) do |i|
+            generate_intermediate_tar(buckets[i], i, prefix)
+          end
+        else
+          chunks = [generate_intermediate_tar(file_list, 0, prefix)]
         end
-      else
-        chunks = [generate_intermediate_tar(file_list, 0)]
+        assemble_bundle(chunks)
+      ensure
+        Dir.glob("#{@server.bundle_dir}/#{prefix}*") { |f| File.unlink(f) }
       end
-      assemble_bundle(chunks)
     end
 
     def full

--- a/lib/taste_tester/client.rb
+++ b/lib/taste_tester/client.rb
@@ -170,7 +170,7 @@ module TasteTester
             name = File.join(file_entry[DESTINATION_PATH_INDEX], file_entry[RELATIVE_PATH_INDEX])
 
             sep_index = file_entry[RELATIVE_PATH_INDEX].index(File::SEPARATOR)
-            minus_first = sep_index.nil? ? '' : file_entry[RELATIVE_PATH_INDEX][sep_index+1..]
+            minus_first = sep_index.nil? ? '' : file_entry[RELATIVE_PATH_INDEX][sep_index+1..-1]
 
             chefignores = Chef::Cookbook::Chefignore.new(file_path)
             next if chefignores.ignored?(file_entry[RELATIVE_PATH_INDEX]) ||

--- a/lib/taste_tester/config.rb
+++ b/lib/taste_tester/config.rb
@@ -38,6 +38,8 @@ module TasteTester
     plugin_path nil
     chef_zero_path nil
     bundle false
+    bundle_compression_level 6
+    bundle_generation_processes nil
     verbosity Logger::WARN
     timestamp false
     user 'root'


### PR DESCRIPTION
Currently Bundle uploads can take a significant amount of time (on the order of 10s of seconds) for larger repos. A significant amount of time is spent checking if the files being uploaded to the bundle match a glob pattern in a chefignores file.

The time complexity of checking chefignores ends up being roughly O(2n*m) where n is the number of files in the repo and m is the number of glob patterns in the chef ignore file. This is only roughly correct since chefignore can be overridden in subdirectories which allows m to be variable.

The previous implementation serially performed a DFS of the repo, checked the chefignore file, and wrote the files to the tgz. This implementation still serially performs a DFS, but it parallelizes the chef ignore check and initial archive generation. It generates intermediate tars in tempfiles, then combines them into a tgz. The user can specify the number of processes used and the compression level via the "bundle_generation_processes" and "bundle_compression_level" config keys respectively. 

One other notable change is that rather than using just the chefignore file in the base repo, this implementation checks for chefignore files per file which allows it to correctly pick up chefignore files in subdirectories. This has a significant performance penalty, but this is regression if offset by the parallelization changes. 

For testing I started with a repo consisting of the cookbooks in https://github.com/facebook/chef-cookbooks
To increase the size of the repo I made fake files using `for i in {1..n}; do base64 /dev/urandom | head -c 10000 > file$i.txt; done` 

| Repo Size           | Implementation | time                                         |
| ------------------- | -------------- | -------------------------------------------- |
| small (674 files)   | old            | real 0m1.041s -- user 0m0.908s -- sys 0m0.127s   |
| small (674 files)   | 32 processes   | real 0m0.995s -- user 0m1.833s -- sys 0m0.810s   |
| small (674 files)   | 4 processes    | real 0m1.096s -- user 0m1.224s -- sys 0m0.287s   |
| small (674 files)   | 1 process      | real 0m1.208s -- user 0m1.019s -- sys 0m0.182s   |
| medium (6293 files) | old            | real 0m2.711s -- user 0m2.438s -- sys 0m0.264s   |
| medium (6293 files) | 32 processes   | real 0m1.609s -- user 0m4.510s -- sys 0m1.261s   |
| medium (6293 files) | 4 processes    | real 0m2.007s -- user 0m3.440s -- sys 0m0.704s   |
| medium (6293 files) | 1 process      | real 0m3.917s -- user 0m3.300s -- sys 0m0.608s   |
| Large (16293)       | old            | real 0m18.197s -- user 0m15.976s -- sys 0m2.167s |
| Large (16293)       | 32 processes   | real 0m12.031s -- user 0m19.636s -- sys 0m3.735s |
| Large (16293)       | 4 processes    | real 0m15.260s -- user 0m18.572s -- sys 0m2.977s |
| Large (16293)       | 1 process      | real 0m23.627s -- user 0m18.591s -- sys 0m4.984s |
