### PR TITLE
Add cli flag for specifying bundle mode

### DIFF
--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -416,7 +416,7 @@ MODES:
       if ['true', 'false'].include?(bundle_setting)
         bundle_setting = bundle_setting == 'true'
       end
-        options[:bundle] = bundle_setting
+      options[:bundle] = bundle_setting
     end
   end
 

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -411,11 +411,11 @@ MODES:
     end
 
     opts.on(
-      "-b", "--bundle BUNDLE_SETTING", ['true', 'false', 'compatible'], "Bundle mode setting"
+      '-b', '--bundle BUNDLE_SETTING', ['true', 'false', 'compatible'], 'Bundle mode setting'
     ) do |bundle_setting|
-        if ['true', 'false'].include?(bundle_setting)
-          bundle_setting = bundle_setting == 'true'
-        end
+      if ['true', 'false'].include?(bundle_setting)
+        bundle_setting = bundle_setting == 'true'
+      end
         options[:bundle] = bundle_setting
     end
   end

--- a/bin/taste-tester
+++ b/bin/taste-tester
@@ -409,6 +409,15 @@ MODES:
     ) do
       options[:skip_post_test_hook] = true
     end
+
+    opts.on(
+      "-b", "--bundle BUNDLE_SETTING", ['true', 'false', 'compatible'], "Bundle mode setting"
+    ) do |bundle_setting|
+        if ['true', 'false'].include?(bundle_setting)
+          bundle_setting = bundle_setting == 'true'
+        end
+        options[:bundle] = bundle_setting
+    end
   end
 
   if mode == 'help'


### PR DESCRIPTION
Bundle mode is much faster, but can break in some edgecases. Allowing a cli arg to override the config value makes it easier for developers to disable it for one-off tests which require standard mode.

With bundle mode set to :compatible mode in my config, both bundle and standard uploads are done:
```
[dtheyer@devvm25808.prn0:tt2]$ /opt/chef-workstation/embedded/bin/ruby ~/tt2/bin/taste-tester upload 
Loading plugin at /etc/taste-tester/hooks/prod-hooks.rb
Starting taste-tester server
Using /home/dtheyer/repo
Doing full upload
Creating bundle...
Running bundle upload
Uploading cookbooks...
Uploading roles...
Uploading databags...
```

When I set bundle mode to true:
```
/opt/chef-workstation/embedded/bin/ruby ~/tt2/bin/taste-tester upload -b true
Loading plugin at /etc/taste-tester/hooks/prod-hooks.rb
Using /home/dtheyer/opsfiles
Doing full upload
Creating bundle...
Running bundle upload
```

When set to false:
```
/opt/chef-workstation/embedded/bin/ruby ~/tt2/bin/taste-tester upload -b false
Loading plugin at /etc/taste-tester/hooks/prod-hooks.rb
Restarting taste-tester server for config change
Using /home/dtheyer/opsfiles
Doing full upload
Uploading cookbooks...
Uploading roles...
Uploading databags...
```

When set to compatible
```
/opt/chef-workstation/embedded/bin/ruby ~/tt2/bin/taste-tester upload -b compatible --skip-repo-checks
Loading plugin at /etc/taste-tester/hooks/prod-hooks.rb
Restarting taste-tester server for config change
Using /home/dtheyer/opsfiles
Doing full upload
Creating bundle...
Running bundle upload
Uploading cookbooks...
...
```