### PR TITLE
fix: remove invalid 'done' keyword from PowerShell tunnel script

### DIFF
--- a/lib/taste_tester/tunnel.rb
+++ b/lib/taste_tester/tunnel.rb
@@ -132,7 +132,6 @@ module TasteTester
         }
         sleep 60
       }
-      done
       EOS
     end
 


### PR DESCRIPTION
## Summary

Removes an invalid `done` keyword from the PowerShell script generated by `windows_tunnel_cmd` in `lib/taste_tester/tunnel.rb`.

## The Bug

The `windows_tunnel_cmd` method generates a PowerShell heredoc for creating SSH tunnels on Windows targets. However, the script incorrectly includes a `done` keyword at the end of the `while` loop:

```powershell
while ($true) {
    # ... loop body ...
    sleep 60
}
done  # <-- Invalid PowerShell syntax
```

## Why This Is Wrong

- `done` is **bash/shell syntax** used to close `while`, `for`, and `until` loops
- **PowerShell uses braces `{}`** to delimit code blocks, not keywords
- A PowerShell `while` loop is simply `while (condition) { body }` - no closing keyword needed
- The `done` line causes a syntax error when Windows attempts to run the tunnel script

## Impact

This bug prevents SSH tunnel creation on Windows targets. When taste-tester attempts to set up a tunnel to a Windows host, PowerShell will reject the script with a syntax error, causing the tunnel setup to fail.

## Fix

Simply remove the stray `done` line. The `while` loop is already properly closed by its closing brace `}`.